### PR TITLE
fix(dictation): stop asking native whether we are recording

### DIFF
--- a/src/hooks/useDictationRecorder.test.tsx
+++ b/src/hooks/useDictationRecorder.test.tsx
@@ -5,57 +5,123 @@ import TestRenderer, { act } from 'react-test-renderer';
 // which registers its release() cleanup FIRST, so it runs before any cleanup declared
 // later in useDictationRecorder. After release the JS object is detached from its
 // native counterpart and every native member access throws.
-const mockState = { released: false };
+//
+// The distinction the tests below lean on is real too: `isRecording` and `uri` are JSI
+// accessors, so a post-release read throws SYNCHRONOUSLY at the access site and no
+// `.catch()` can intercept it, while `stop()` is an AsyncFunction whose failure arrives
+// as a rejection.
+const mockState = {
+  released: false,
+  recording: false,
+  // Reads of a native property that happened after release. Any of these is a fatal
+  // in the app, so the hook must never make one.
+  readsAfterRelease: [] as string[],
+  // Set to a promise to hold stop() open, so a stop can be left in flight across the
+  // sheet closing.
+  holdStop: null as Promise<void> | null,
+  stopCalls: 0,
+  // Make the next stop() reject, as a refused native stop does.
+  failStop: false,
+  // Every native property the hook read, released or not. `isRecording` must never
+  // appear: the hook knows whether it started the recorder, so consulting native for
+  // it buys nothing and puts a throwing accessor on paths that straddle the close.
+  propertyReads: [] as string[],
+};
+
 const mockSetAudioModeAsync = jest.fn(async () => undefined);
 
 function mockThrowIfReleased(member: string) {
   if (mockState.released) {
+    mockState.readsAfterRelease.push(member);
     throw new Error(
       `Unable to find the native shared object associated with given JavaScript object (${member})`,
     );
   }
 }
 
-jest.mock('expo-audio', () => ({
-  RecordingPresets: { HIGH_QUALITY: {} },
-  requestRecordingPermissionsAsync: jest.fn(async () => ({ granted: true })),
-  setAudioModeAsync: (...args: any[]) => (mockSetAudioModeAsync as any)(...args),
-  useAudioRecorder: () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { useEffect } = require('react');
-    useEffect(
-      () => () => {
-        mockState.released = true;
-      },
-      [],
-    );
-    return {
-      get isRecording() {
-        mockThrowIfReleased('isRecording');
-        return false;
-      },
-      get uri() {
-        mockThrowIfReleased('uri');
-        return null;
-      },
-      record: jest.fn(() => mockThrowIfReleased('record')),
-      stop: jest.fn(async () => mockThrowIfReleased('stop')),
-      prepareToRecordAsync: jest.fn(async () => mockThrowIfReleased('prepareToRecordAsync')),
-    };
-  },
-}));
+jest.mock('expo-audio', () => {
+  const makeRecorder = () => ({
+    get isRecording() {
+      mockState.propertyReads.push('isRecording');
+      mockThrowIfReleased('isRecording');
+      return mockState.recording;
+    },
+    get uri() {
+      mockState.propertyReads.push('uri');
+      mockThrowIfReleased('uri');
+      return 'file:///dictation.m4a';
+    },
+    record: jest.fn(() => {
+      mockThrowIfReleased('record');
+      mockState.recording = true;
+    }),
+    // Async, so a released object rejects rather than throwing at the call site.
+    stop: jest.fn(async () => {
+      mockState.stopCalls += 1;
+      mockThrowIfReleased('stop');
+      if (mockState.failStop) {
+        throw new Error('stop refused');
+      }
+      if (mockState.holdStop) {
+        await mockState.holdStop;
+      }
+      mockState.recording = false;
+    }),
+    prepareToRecordAsync: jest.fn(async () => mockThrowIfReleased('prepareToRecordAsync')),
+  });
+
+  return {
+    RecordingPresets: { HIGH_QUALITY: {} },
+    requestRecordingPermissionsAsync: jest.fn(async () => ({ granted: true })),
+    setAudioModeAsync: (...args: any[]) => (mockSetAudioModeAsync as any)(...args),
+    useAudioRecorder: () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { useEffect, useRef } = require('react');
+      // useReleasingSharedObject hands back the SAME object across renders.
+      const ref = useRef(null);
+      if (!ref.current) {
+        ref.current = makeRecorder();
+      }
+      useEffect(
+        () => () => {
+          mockState.released = true;
+        },
+        [],
+      );
+      return ref.current;
+    },
+  };
+});
 
 // eslint-disable-next-line import/first
 import { useDictationRecorder } from './useDictationRecorder';
 
+type Api = ReturnType<typeof useDictationRecorder>;
+
+let api: Api;
+
 function Probe() {
-  useDictationRecorder({ maxSeconds: 300 });
+  api = useDictationRecorder({ maxSeconds: 300 });
   return null;
+}
+
+function mount() {
+  let renderer: any;
+  act(() => {
+    renderer = TestRenderer.create(<Probe />);
+  });
+  return renderer;
 }
 
 describe('useDictationRecorder unmount', () => {
   beforeEach(() => {
     mockState.released = false;
+    mockState.recording = false;
+    mockState.readsAfterRelease = [];
+    mockState.holdStop = null;
+    mockState.stopCalls = 0;
+    mockState.failStop = false;
+    mockState.propertyReads = [];
     mockSetAudioModeAsync.mockClear();
   });
 
@@ -63,21 +129,102 @@ describe('useDictationRecorder unmount', () => {
   // closes the dictation sheet. Touching the recorder here used to throw an uncaught
   // fatal, because expo-audio had already released it.
   it('does not touch the recorder after expo-audio released it', () => {
-    let renderer: any;
-    act(() => {
-      renderer = TestRenderer.create(<Probe />);
-    });
+    const renderer = mount();
 
     expect(() => act(() => renderer.unmount())).not.toThrow();
+    expect(mockState.readsAfterRelease).toEqual([]);
   });
 
   it('still deactivates the recording session on unmount', () => {
-    let renderer: any;
-    act(() => {
-      renderer = TestRenderer.create(<Probe />);
-    });
+    const renderer = mount();
     act(() => renderer.unmount());
 
     expect(mockSetAudioModeAsync).toHaveBeenCalledWith({ allowsRecording: false });
+  });
+
+  // Done is tappable while recording, so this is the close path with the recorder
+  // still running underneath it.
+  it('does not touch the recorder when the sheet closes mid-recording', async () => {
+    const renderer = mount();
+    await act(async () => {
+      await api.start();
+    });
+    expect(mockState.recording).toBe(true);
+
+    expect(() => act(() => renderer.unmount())).not.toThrow();
+    expect(mockState.readsAfterRelease).toEqual([]);
+    expect(mockState.propertyReads).not.toContain('isRecording');
+  });
+
+  // reset() runs from close() and from the sheet's onClose prop. It is a plain
+  // synchronous function, so a native property read inside it would be fatal rather
+  // than a rejection if the ordering ever put it after release.
+  it('reset stops a running recorder without reading a native property', async () => {
+    const renderer = mount();
+    await act(async () => {
+      await api.start();
+    });
+
+    act(() => api.reset());
+    expect(mockState.recording).toBe(false);
+    expect(mockState.stopCalls).toBe(1);
+
+    // A second reset must not float another stop at an object it no longer owns.
+    act(() => api.reset());
+    expect(mockState.stopCalls).toBe(1);
+
+    expect(() => act(() => renderer.unmount())).not.toThrow();
+    expect(mockState.readsAfterRelease).toEqual([]);
+    expect(mockState.propertyReads).not.toContain('isRecording');
+  });
+
+  // The sheet takes ~300ms to animate out before it unmounts, so a slow flush can
+  // still be in flight when expo-audio releases the recorder underneath it.
+  it('does not read the recorder from a stop that outlived the sheet', async () => {
+    let releaseStop: () => void = () => undefined;
+    mockState.holdStop = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+
+    const renderer = mount();
+    await act(async () => {
+      await api.start();
+    });
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = api.stop();
+    });
+
+    act(() => renderer.unmount());
+
+    await act(async () => {
+      releaseStop();
+      await pending;
+    });
+
+    expect(mockState.readsAfterRelease).toEqual([]);
+  });
+
+  // A refused stop leaves the microphone open, and the hook can no longer ask native
+  // whether it is. It has to remember, so closing still makes one last attempt.
+  it('retries the stop on close when the recorder refused to stop', async () => {
+    const renderer = mount();
+    await act(async () => {
+      await api.start();
+    });
+
+    mockState.failStop = true;
+    await act(async () => {
+      await api.stop();
+    });
+    expect(api.state).toBe('failed');
+
+    mockState.failStop = false;
+    act(() => api.reset());
+    expect(mockState.recording).toBe(false);
+
+    expect(() => act(() => renderer.unmount())).not.toThrow();
+    expect(mockState.propertyReads).not.toContain('isRecording');
   });
 });

--- a/src/hooks/useDictationRecorder.ts
+++ b/src/hooks/useDictationRecorder.ts
@@ -52,6 +52,18 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   // Bumped by every reset/unmount. start() captures the value it began with, so a
   // permission prompt answered after the sheet closed can tell it is stale.
   const generationRef = useRef(0);
+  // Whether the native recorder is running, tracked here rather than read back from
+  // `recorder.isRecording`.
+  //
+  // Every property on an expo shared object is a JSI accessor that calls into native
+  // synchronously, and once expo-audio has released the object that call throws a
+  // jsi::JSError at the access site -- NativeSharedObjectNotFoundException on iOS,
+  // UsingReleasedSharedObjectException on Android. It is a synchronous throw, so a
+  // `.catch()` cannot intercept it, and registered sheets unmount on hide and render
+  // outside the app's ErrorBoundary, so any such read on a path that can straddle the
+  // close is fatal. A plain ref cannot fault, and it stays correct across the release
+  // because nothing native has to be consulted to know what we ourselves started.
+  const isRecordingRef = useRef(false);
 
   // Round UP: the server bills whole units off the real duration, so flooring would
   // quote one unit for a clip that crosses into two.
@@ -65,16 +77,35 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   }, []);
 
   const stop = useCallback(async () => {
-    if (!recorder.isRecording) {
+    if (!isRecordingRef.current) {
       return;
     }
+    isRecordingRef.current = false;
     clearTick();
     // Wall clock, captured before the native call so a slow stop does not inflate
     // the quote. This is the figure the user sees and is charged on.
     const elapsed = Date.now() - startedAtRef.current;
+    const generation = generationRef.current;
+    let uri: string | null = null;
     try {
       await recorder.stop();
+      if (generation !== generationRef.current) {
+        // The sheet was closed while the recorder was flushing. Its shared object is
+        // already released, so `recorder.uri` below would fault, and there is no
+        // longer anything to submit.
+        return;
+      }
+      // Read inside the try, and only after the generation check: this is a native
+      // getter, and a stop that outlives the sheet must not take the app with it.
+      ({ uri } = recorder);
     } catch {
+      if (generation !== generationRef.current) {
+        return;
+      }
+      // The stop was refused, so the microphone may well still be open. Say so again,
+      // and reset() on the way out will make one more attempt rather than leaving it
+      // running for as long as the sheet stays up.
+      isRecordingRef.current = true;
       // Leaving state as 'recording' would strand the sheet: the stop button stays
       // up but no longer works, and there is no recording to submit either.
       setResult(null);
@@ -83,7 +114,7 @@ export function useDictationRecorder({ maxSeconds }: Options) {
     }
     // Kept rather than zeroed, so the sheet can show what was actually recorded.
     setDurationMs(elapsed);
-    setResult(recorder.uri ? { uri: recorder.uri, durationMs: elapsed } : null);
+    setResult(uri ? { uri, durationMs: elapsed } : null);
     setState('stopped');
   }, [recorder, clearTick]);
 
@@ -122,6 +153,9 @@ export function useDictationRecorder({ maxSeconds }: Options) {
 
       startedAtRef.current = Date.now();
       recorder.record();
+      // Only after record() returns: it is a synchronous native call, and if it
+      // throws there is nothing running to stop.
+      isRecordingRef.current = true;
       setState('recording');
 
       clearTick();
@@ -141,8 +175,11 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   const reset = useCallback(() => {
     generationRef.current += 1;
     clearTick();
-    if (recorder.isRecording) {
-      // Fire-and-forget, but caught: an unhandled rejection here would surface over
+    if (isRecordingRef.current) {
+      isRecordingRef.current = false;
+      // Fire-and-forget, but caught: stop() is an AsyncFunction, so unlike the
+      // property getters it reports a released object as a rejection rather than a
+      // synchronous throw, and an unhandled rejection would surface as a redbox over
       // a teardown the user cannot act on anyway.
       recorder.stop().catch(() => undefined);
     }
@@ -177,6 +214,7 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   useEffect(
     () => () => {
       generationRef.current += 1;
+      isRecordingRef.current = false;
       if (tickRef.current) {
         clearInterval(tickRef.current);
       }


### PR DESCRIPTION
Follow-up to #3467, which fixed the Done-tap fatal by taking the recorder out of the unmount cleanup. Three reads of the shared object survive it, and two sit on paths that can straddle the close.

`recorder.isRecording` and `recorder.uri` are JSI accessors, so once expo-audio has released the object they throw synchronously at the access site. A `.catch()` cannot intercept that, and sheets render outside the app's `ErrorBoundary`.

- `reset()` reads `isRecording`. It is a plain synchronous function wired to both `close()` and the sheet's `onClose` prop, and `onClose` firing before the unmount rather than after is an ordering detail of actions-sheet 0.9.7 (`index.js:401` runs before the `:408` publish), not something the hook guarantees.
- `stop()` reads `recorder.uri` after awaiting the native stop, with nothing checking that the sheet is still open. Done stays tappable while recording, so a slow flush can outlive it. Today that surfaces as an unhandled rejection rather than a fatal, because the read is inside an `async` function.

The hook already knows whether it started the recorder, so it keeps that in a ref and stops consulting native for it. `stop()` reads the uri inside its `try` and only past a generation check, and a refused stop marks the recorder running again so the close path makes one more attempt rather than leaving the microphone open for as long as the sheet is up.

Tests cover closing mid-recording, `reset()`, a stop that outlives the sheet, and the refused stop. Three of the six fail against the current hook. The mock now models the distinction the fix turns on: a property read throws where an `AsyncFunction` rejects.

## Note on the reported crash

The Done-tap crash is still being seen on device, and that is a build gap rather than a code gap. The last `development` build ran 2026-08-06 06:36 UTC on 7723af7635; #3467 merged the same day at 19:32 UTC. So the newest builds in Sentry, `3.5.8+1785998810` (Android) and `3.5.8+1785998515` (iOS), both predate the fix, and the Android one was still reporting events this morning. A build containing #3467 started today at 05:57 UTC and is the first that can be used to verify either change.

Neither #3467 nor this PR has been checked on a device.

## Test plan

- `yarn test:ci` — 742 tests, 6 in `useDictationRecorder.test.tsx`
- `yarn typecheck` — 0 errors
- `yarn lint` — clean
- Device check, once a build with both changes exists: dictate, tap Done; tap Done mid-recording; backdrop tap, back press, and open/close without recording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation recorder cleanup when recording ends or the recorder is unmounted.
  * Prevented errors when native recorder resources are released during stop or reset operations.
  * Recording state now remains accurate when starting or stopping fails.
  * Improved recovery and retry behavior after failed recording stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->