### PR TITLE
Report the silenced dictation failures to Sentry

### DIFF
--- a/src/components/dictationModal/dictationModal.tsx
+++ b/src/components/dictationModal/dictationModal.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
 import { useQuery } from '@tanstack/react-query';
 import { getAiTranscribePriceQueryOptions, useAiTranscribe } from '@ecency/sdk';
+import { captureException } from '../../utils/sentryUtils';
 import { useAuth } from '../../hooks';
 import { useDictationRecorder } from '../../hooks/useDictationRecorder';
 import { SheetNames } from '../../navigation/sheets';
@@ -155,6 +156,15 @@ export const DictationModal = ({ payload }: SheetProps<SheetNames.DICTATION>) =>
           : status === 400
           ? 'dictation.error_too_long'
           : 'dictation.error_failed';
+      if (id === 'dictation.error_failed') {
+        // The three status codes above are conditions the user can act on and the
+        // message already says so. Anything else is a defect, and the Points were
+        // charged or not on the server's terms, so it needs to be diagnosable.
+        captureException(err, (scope) => {
+          scope.setTag('context', 'dictation-transcribe');
+          scope.setTag('dictation_status', String(status ?? 'none'));
+        });
+      }
       Alert.alert(intl.formatMessage({ id: 'alert.fail' }), intl.formatMessage({ id }));
       // Recording and key are both kept: retry reuses the audio, and the same key
       // means a request that actually landed replays rather than charging twice.

--- a/src/hooks/useDictationRecorder.test.tsx
+++ b/src/hooks/useDictationRecorder.test.tsx
@@ -29,6 +29,26 @@ const mockState = {
 };
 
 const mockSetAudioModeAsync = jest.fn(async () => undefined);
+const mockCaptureException = jest.fn();
+
+jest.mock('../utils/sentryUtils', () => ({
+  captureException: (...args: any[]) => (mockCaptureException as any)(...args),
+  captureMessage: jest.fn(),
+}));
+
+// The scope mutator is where the context tag lives, so run it against a stub to see
+// which flow each report was filed under.
+function capturedContexts() {
+  return mockCaptureException.mock.calls.map(([, applyScope]: any[]) => {
+    const tags: Record<string, string> = {};
+    applyScope?.({
+      setTag: (key: string, value: string) => {
+        tags[key] = value;
+      },
+    });
+    return tags.context;
+  });
+}
 
 function mockThrowIfReleased(member: string) {
   if (mockState.released) {
@@ -123,6 +143,7 @@ describe('useDictationRecorder unmount', () => {
     mockState.failStop = false;
     mockState.propertyReads = [];
     mockSetAudioModeAsync.mockClear();
+    mockCaptureException.mockClear();
   });
 
   // Registered sheets unmount on hide, so this is what happens every time the user
@@ -133,6 +154,8 @@ describe('useDictationRecorder unmount', () => {
 
     expect(() => act(() => renderer.unmount())).not.toThrow();
     expect(mockState.readsAfterRelease).toEqual([]);
+    // A clean close is not an incident.
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it('still deactivates the recording session on unmount', () => {
@@ -219,6 +242,9 @@ describe('useDictationRecorder unmount', () => {
       await api.stop();
     });
     expect(api.state).toBe('failed');
+    // Used to be swallowed by a bare catch, which is why none of this was ever
+    // visible in Sentry.
+    expect(capturedContexts()).toContain('dictation-recorder-stop');
 
     mockState.failStop = false;
     act(() => api.reset());

--- a/src/hooks/useDictationRecorder.ts
+++ b/src/hooks/useDictationRecorder.ts
@@ -5,6 +5,7 @@ import {
   setAudioModeAsync,
   useAudioRecorder,
 } from 'expo-audio';
+import { captureException } from '../utils/sentryUtils';
 
 export type DictationRecorderState =
   | 'idle'
@@ -86,22 +87,23 @@ export function useDictationRecorder({ maxSeconds }: Options) {
     // the quote. This is the figure the user sees and is charged on.
     const elapsed = Date.now() - startedAtRef.current;
     const generation = generationRef.current;
-    let uri: string | null = null;
+    // Read BEFORE awaiting the stop. `uri` is the output path the recorder was
+    // prepared with rather than something the stop produces, so it is already correct
+    // here, and reading it afterwards would leave a native getter on the far side of
+    // an await that closing the sheet can outlive.
+    const { uri } = recorder;
     try {
       await recorder.stop();
       if (generation !== generationRef.current) {
-        // The sheet was closed while the recorder was flushing. Its shared object is
-        // already released, so `recorder.uri` below would fault, and there is no
-        // longer anything to submit.
+        // The sheet was closed while the recorder was flushing, so there is nothing
+        // left to submit and nothing mounted to submit it to.
         return;
       }
-      // Read inside the try, and only after the generation check: this is a native
-      // getter, and a stop that outlives the sheet must not take the app with it.
-      ({ uri } = recorder);
-    } catch {
+    } catch (error) {
       if (generation !== generationRef.current) {
         return;
       }
+      captureException(error, (scope) => scope.setTag('context', 'dictation-recorder-stop'));
       // The stop was refused, so the microphone may well still be open. Say so again,
       // and reset() on the way out will make one more attempt rather than leaving it
       // running for as long as the sheet stays up.
@@ -162,12 +164,13 @@ export function useDictationRecorder({ maxSeconds }: Options) {
       tickRef.current = setInterval(() => {
         setDurationMs(Date.now() - startedAtRef.current);
       }, 250);
-    } catch {
+    } catch (error) {
       if (generation !== generationRef.current) {
         // A rejection from a superseded attempt must not clobber the recording that
         // replaced it, same as the denial path above.
         return;
       }
+      captureException(error, (scope) => scope.setTag('context', 'dictation-recorder-start'));
       setState('failed');
     }
   }, [recorder, clearTick]);
@@ -181,7 +184,9 @@ export function useDictationRecorder({ maxSeconds }: Options) {
       // property getters it reports a released object as a rejection rather than a
       // synchronous throw, and an unhandled rejection would surface as a redbox over
       // a teardown the user cannot act on anyway.
-      recorder.stop().catch(() => undefined);
+      recorder.stop().catch((error) => {
+        captureException(error, (scope) => scope.setTag('context', 'dictation-recorder-reset'));
+      });
     }
     setResult(null);
     setDurationMs(0);
@@ -193,7 +198,9 @@ export function useDictationRecorder({ maxSeconds }: Options) {
   // duration drifts past while the recorder flushes.
   useEffect(() => {
     if (state === 'recording' && durationMs >= (maxSeconds - 1) * 1000) {
-      stop().catch(() => undefined);
+      stop().catch((error) => {
+        captureException(error, (scope) => scope.setTag('context', 'dictation-recorder-cap'));
+      });
     }
   }, [state, durationMs, maxSeconds, stop]);
 
@@ -218,7 +225,9 @@ export function useDictationRecorder({ maxSeconds }: Options) {
       if (tickRef.current) {
         clearInterval(tickRef.current);
       }
-      setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
+      setAudioModeAsync({ allowsRecording: false }).catch((error) => {
+        captureException(error, (scope) => scope.setTag('context', 'dictation-audio-mode-release'));
+      });
     },
     [],
   );


### PR DESCRIPTION
Follow-up to #3474. That PR made the close path safe; this one makes it observable.

Every expo-audio call in the dictation flow was wrapped in a bare `catch {}` or `.catch(() => undefined)`, so the whole class of native failure was invisible by construction. A released-shared-object throw, a refused stop, a denied audio session and a failed session teardown all reported nothing anywhere, and neither dictation file imported Sentry at all. Searching Sentry for the Done-tap crash returns zero events across the org for 90 days, and that is a true negative rather than a bad query.

Each of the five swallowed sites now captures with a context tag naming the flow, following 937eaee8c4:

- `dictation-recorder-start` — permissions, audio session, prepare
- `dictation-recorder-stop` — a refused native stop
- `dictation-recorder-reset` — the floated stop on teardown
- `dictation-recorder-cap` — the auto-stop at max duration
- `dictation-audio-mode-release` — deactivating the recording session on close

Transcription reports only the unexpected failures. 402, 429 and 400 are conditions the user can act on and the alert already says so, so only the generic fallback is filed, tagged with the status it arrived with.

Also reads the recorder's uri before awaiting the stop rather than after. It is the path the recorder was prepared with, not something the stop produces, so hoisting it removes the last native getter sitting on the far side of an await that closing the sheet can outlive. #3474 guarded that read with a generation check; this removes the need for one.

Checked that this will not be noisy on Android: `setAudioModeAsync({ allowsRecording: false })` maps to three `undefined` fields there (`ExpoAudio.js:86-94`), and the Kotlin `AudioMode` record gives `shouldPlayInBackground` a default and makes the other two nullable (`AudioRecords.kt:14-18`), so it does not reject.

## Test plan

- `yarn test:ci` — 743 tests, 6 in `useDictationRecorder.test.tsx`, including one asserting a refused stop is filed under `dictation-recorder-stop` and one asserting a clean close files nothing
- `yarn typecheck` — 0 errors
- `yarn lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for unexpected dictation transcription and recorder failures.
  * Added clearer diagnostic context for recorder start, stop, reset, duration-limit, and cleanup errors.
  * Prevented potential audio state access issues when stopping dictation recording.
  * Preserved existing handling for known transcription errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->