### PR TITLE
quests: refresh on resume and after a recorded activity

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.76",
+    "@ecency/sdk": "^2.3.79",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/providers/queries/leaderboardQueries/leaderboardQueries.ts
+++ b/src/providers/queries/leaderboardQueries/leaderboardQueries.ts
@@ -3,5 +3,12 @@ import { getDiscoverLeaderboardQueryOptions } from '@ecency/sdk';
 
 /** hook used to return leaderboard data using SDK */
 export const useGetLeaderboardQuery = (duration: 'day' | 'week' | 'month') => {
-  return useQuery(getDiscoverLeaderboardQueryOptions(duration));
+  return useQuery({
+    ...getDiscoverLeaderboardQueryOptions(duration),
+    // Opted in explicitly: the client default is off, because waking every query in
+    // the cache on every resume is far more than this needs. The board lives inside a
+    // tab that stays mounted, so without this it shows whatever it fetched hours ago
+    // until the user thinks to pull to refresh.
+    refetchOnWindowFocus: true,
+  });
 };

--- a/src/providers/queries/pointQueries.ts
+++ b/src/providers/queries/pointQueries.ts
@@ -17,6 +17,13 @@ interface UserActivityMutationVars {
   blockNum?: string | number;
   transactionId?: string;
   cacheId?: string;
+  /**
+   * Who performed the activity, captured when it happened. The quest refresh fires a
+   * minute later, by which time `currentAccount` may be someone else: without this, a
+   * switch mid-flight refreshes the wrong account and leaves the real one stale.
+   * Replayed activities already carry it from the redux queue.
+   */
+  username?: string;
 }
 
 /**
@@ -75,7 +82,7 @@ export const useUserActivityMutation = () => {
       // The activity is only recorded here, not yet credited. Ask again once the
       // backend has had time to verify and process it, otherwise the quest card and
       // the editor chip keep showing pre-action numbers until something remounts.
-      scheduleQuestsRefresh(queryClient, currentAccount?.name);
+      scheduleQuestsRefresh(queryClient, vars.username ?? currentAccount?.name);
     },
     onError: (error, vars) => {
       console.log('failed to log activity', error, vars);
@@ -146,7 +153,7 @@ export const useCheckIn = () => {
     // replay, but a rejected call shouldn't also mute the next 15 minutes.
     lastCheckinAt[username] = now;
     mutate(
-      { pointsTy: PointActivityIds.CHECKIN },
+      { pointsTy: PointActivityIds.CHECKIN, username },
       {
         onError: () => {
           if (lastCheckinAt[username] === now) {

--- a/src/providers/queries/pointQueries.ts
+++ b/src/providers/queries/pointQueries.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getPointsQueryOptions, getQuestsQueryOptions } from '@ecency/sdk';
+import { scheduleQuestsRefresh } from '../../utils/refreshQuests';
 import { useAppSelector, useAppDispatch } from '../../hooks';
 import {
   deletePointActivityCache,
@@ -41,11 +42,16 @@ export const useGetQuestsQuery = (username?: string) => {
   return useQuery({
     ...getQuestsQueryOptions(username),
     enabled: !!username,
+    // Opted in explicitly: the client default is off, because waking every query in
+    // the cache on every resume is far more than this needs. Quest progress is the
+    // thing users come back to the app to look at.
+    refetchOnWindowFocus: true,
   });
 };
 
 export const useUserActivityMutation = () => {
   const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
   const currentAccount = useAppSelector(selectCurrentAccount);
   const pointActivitiesCache: Map<string, PointActivity> = useAppSelector(
     (state) => state.cache.pointActivities,
@@ -66,6 +72,10 @@ export const useUserActivityMutation = () => {
         console.log('must remove from redux');
         dispatch(deletePointActivityCache(vars.cacheId));
       }
+      // The activity is only recorded here, not yet credited. Ask again once the
+      // backend has had time to verify and process it, otherwise the quest card and
+      // the editor chip keep showing pre-action numbers until something remounts.
+      scheduleQuestsRefresh(queryClient, currentAccount?.name);
     },
     onError: (error, vars) => {
       console.log('failed to log activity', error, vars);

--- a/src/providers/sdk/mobilePlatformAdapter.ts
+++ b/src/providers/sdk/mobilePlatformAdapter.ts
@@ -66,6 +66,7 @@ interface MobilePlatformAdapterParams {
     pointsTy: number;
     transactionId: string;
     blockNum?: number;
+    username?: string;
   }) => void;
 }
 
@@ -243,7 +244,14 @@ export function createMobilePlatformAdapter(params: MobilePlatformAdapterParams)
 
     recordActivity: async (activityType: number, txId: string, blockNum?: number) => {
       if (userActivityMutate) {
-        userActivityMutate({ pointsTy: activityType, transactionId: txId, blockNum });
+        // Capture who broadcast this now. The quest refresh it schedules fires a minute
+        // later, and reading the account then would follow an account switch.
+        userActivityMutate({
+          pointsTy: activityType,
+          transactionId: txId,
+          blockNum,
+          username: store.getState().account?.currentAccount?.name,
+        });
       }
     },
 

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -10,6 +10,7 @@ import BackgroundTimer from 'react-native-background-timer';
 import { Image as ExpoImage } from 'expo-image';
 import { setProxyBase } from '@ecency/render-helper';
 import { ConfigManager } from '@ecency/sdk';
+import { focusManager } from '@tanstack/react-query';
 import { useAppDispatch, useAppSelector, useLinkProcessor } from '../../../hooks';
 import { setDeviceOrientation, setLockedOrientation } from '../../../redux/actions/uiAction';
 import { orientations } from '../../../redux/constants/orientationsConstants';
@@ -184,6 +185,14 @@ export const useInitApplication = () => {
   };
 
   const _handleAppStateChange = (nextAppState: any) => {
+    // React Native has no window focus events, so React Query's focus tracking is
+    // inert until something drives it. Without this, `refetchOnWindowFocus` is not
+    // merely disabled by default, it has no signal to act on at all, and a screen
+    // that stays mounted (the leaderboard tab, the perks card) keeps serving
+    // whatever it fetched before the app was backgrounded. Only the queries that
+    // opt in refetch, so this does not wake the whole cache on every resume.
+    focusManager.setFocused(nextAppState === 'active');
+
     if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
       userActivityMutation.lazyMutatePendingActivities();
       dispatch(recordAppSession());

--- a/src/utils/refreshQuests.test.ts
+++ b/src/utils/refreshQuests.test.ts
@@ -56,6 +56,22 @@ describe('scheduleQuestsRefresh', () => {
     });
   });
 
+  it('keeps a pending refresh per account, so a switch cannot cancel the other', () => {
+    scheduleQuestsRefresh(queryClient, 'alice');
+    jest.advanceTimersByTime(5 * 1000);
+    scheduleQuestsRefresh(queryClient, 'bob');
+
+    jest.advanceTimersByTime(QUESTS_REFRESH_DELAY + 1000);
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(2);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['quests', 'status', 'alice'],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['quests', 'status', 'bob'],
+    });
+  });
+
   it('does nothing without a username', () => {
     scheduleQuestsRefresh(queryClient, undefined);
     scheduleQuestsRefresh(queryClient, null);

--- a/src/utils/refreshQuests.test.ts
+++ b/src/utils/refreshQuests.test.ts
@@ -1,0 +1,67 @@
+import { cancelQuestsRefresh, QUESTS_REFRESH_DELAY, scheduleQuestsRefresh } from './refreshQuests';
+
+jest.mock('@ecency/sdk', () => ({
+  QueryKeys: {
+    quests: { status: (username?: string) => ['quests', 'status', username] },
+  },
+}));
+
+const invalidateQueries = jest.fn();
+const queryClient = { invalidateQueries } as any;
+
+describe('scheduleQuestsRefresh', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    invalidateQueries.mockClear();
+  });
+
+  afterEach(() => {
+    cancelQuestsRefresh();
+    jest.useRealTimers();
+  });
+
+  it('waits for the backend to actually credit the action before refetching', () => {
+    scheduleQuestsRefresh(queryClient, 'alice');
+
+    // A chain action is verified and processed a little over a minute after it is
+    // broadcast. Asking sooner reads the pre-action numbers and then marks them
+    // fresh, so the real update is never picked up.
+    jest.advanceTimersByTime(10 * 1000);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(QUESTS_REFRESH_DELAY);
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['quests', 'status', 'alice'],
+    });
+  });
+
+  it('coalesces a burst of actions into one request', () => {
+    scheduleQuestsRefresh(queryClient, 'alice');
+    jest.advanceTimersByTime(5 * 1000);
+    scheduleQuestsRefresh(queryClient, 'alice');
+    jest.advanceTimersByTime(5 * 1000);
+    scheduleQuestsRefresh(queryClient, 'alice');
+
+    jest.advanceTimersByTime(QUESTS_REFRESH_DELAY + 1000);
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips a leading @ so the key matches the query', () => {
+    scheduleQuestsRefresh(queryClient, '@alice');
+    jest.advanceTimersByTime(QUESTS_REFRESH_DELAY + 1000);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['quests', 'status', 'alice'],
+    });
+  });
+
+  it('does nothing without a username', () => {
+    scheduleQuestsRefresh(queryClient, undefined);
+    scheduleQuestsRefresh(queryClient, null);
+    scheduleQuestsRefresh(queryClient, '');
+    jest.advanceTimersByTime(QUESTS_REFRESH_DELAY + 1000);
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/refreshQuests.ts
+++ b/src/utils/refreshQuests.ts
@@ -1,0 +1,52 @@
+import { QueryClient } from '@tanstack/react-query';
+import { QueryKeys } from '@ecency/sdk';
+
+/**
+ * How long to wait before asking the backend for updated quest progress.
+ *
+ * A blockchain action is not credited the moment it is broadcast: it has to be
+ * verified against the chain and then processed before it counts, which lands a
+ * little over a minute after the fact. Refreshing sooner just re-reads the
+ * pre-action numbers and, because the answer is then fresh for the query's
+ * staleTime, actively prevents the real update from being picked up.
+ */
+export const QUESTS_REFRESH_DELAY = 70 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Debounced refresh of the quests/streak query so the perks quest card and the
+ * editor quest chip catch up after a points-earning action.
+ *
+ * The debounce coalesces a burst of actions into a single `/private-api/quests`
+ * request, and invalidating (rather than refetching) means nothing goes over the
+ * wire unless a screen is actually observing the query.
+ *
+ * Unlike the website this is not skipped for votes. The website excludes them
+ * because its debounce is short enough that fast feed voting would fan out
+ * requests; at this delay a voting burst collapses into one request after the
+ * user stops, and the daily vote quest is exactly one people watch.
+ */
+export const scheduleQuestsRefresh = (queryClient: QueryClient, username?: string | null) => {
+  const name = username?.replace('@', '');
+  if (!name) {
+    return;
+  }
+
+  if (timer) {
+    clearTimeout(timer);
+  }
+
+  timer = setTimeout(() => {
+    timer = null;
+    queryClient.invalidateQueries({ queryKey: QueryKeys.quests.status(name) });
+  }, QUESTS_REFRESH_DELAY);
+};
+
+/** Test seam: drop any pending refresh so specs do not leak timers into each other. */
+export const cancelQuestsRefresh = () => {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+};

--- a/src/utils/refreshQuests.ts
+++ b/src/utils/refreshQuests.ts
@@ -12,7 +12,14 @@ import { QueryKeys } from '@ecency/sdk';
  */
 export const QUESTS_REFRESH_DELAY = 70 * 1000;
 
-let timer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * One pending refresh per account. A single shared timer would let a second account
+ * cancel the first one's only scheduled invalidation: record something as alice, switch
+ * to bob and record something within the delay, and alice's quest data stays stale until
+ * a screen remounts. Account switching is a first-class flow here, so the timers are
+ * keyed by username.
+ */
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /**
  * Debounced refresh of the quests/streak query so the perks quest card and the
@@ -33,20 +40,22 @@ export const scheduleQuestsRefresh = (queryClient: QueryClient, username?: strin
     return;
   }
 
-  if (timer) {
-    clearTimeout(timer);
+  const pending = timers.get(name);
+  if (pending) {
+    clearTimeout(pending);
   }
 
-  timer = setTimeout(() => {
-    timer = null;
-    queryClient.invalidateQueries({ queryKey: QueryKeys.quests.status(name) });
-  }, QUESTS_REFRESH_DELAY);
+  timers.set(
+    name,
+    setTimeout(() => {
+      timers.delete(name);
+      queryClient.invalidateQueries({ queryKey: QueryKeys.quests.status(name) });
+    }, QUESTS_REFRESH_DELAY),
+  );
 };
 
 /** Test seam: drop any pending refresh so specs do not leak timers into each other. */
 export const cancelQuestsRefresh = () => {
-  if (timer) {
-    clearTimeout(timer);
-    timer = null;
-  }
+  timers.forEach((pending) => clearTimeout(pending));
+  timers.clear();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.76":
-  version "2.3.76"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.76.tgz#5707fd077fed1f82436e8e024595d67766e343c3"
-  integrity sha512-30yhsRghULNW4lQIYiaWvLguAnLLjk06KCy2nh7sUKwxrxr6MmYQQ+m74ym6kBp8Nz2PXP8XJ3sCz5JqjmdiNQ==
+"@ecency/sdk@^2.3.79":
+  version "2.3.79"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.79.tgz#fd31c179eef7d1478cd2296f4a17f715400ade7e"
+  integrity sha512-zpsj4+uAbXM9g7FLHCBvszDjnQtCaH/TcqgkFhtcsP6EDLu+MEaKWF26fs6Tfz3WXhbt4rUv0o5tltEAdR0Gpg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Closes #3471.

Two gaps that compound into "the quest counter and the leaderboard badge are frozen".

## Nothing refetched on resume

React Native has no window focus events, so React Query's focus tracking is inert until something drives it. `refetchOnWindowFocus: false` in the query client was not merely a preference, there was no signal to act on either way. The existing `_handleAppStateChange` replayed pending point activities and recorded a session but touched no query cache, so a screen that stays mounted (the leaderboard inside the Notifications tab, the perks quest card) kept serving whatever it fetched before the app was backgrounded until the user thought to pull to refresh.

`AppState` now drives `focusManager`, and the two queries that want it opt in explicitly. The client default stays off, so this does not wake every query in the cache on every resume.

## Nothing invalidated the quests query after an action

The website has `scheduleQuestsRefresh` wired into publish, reply, reblog, wave submit and follow. The app had no equivalent, so `useUserActivityMutation` recorded the activity and the quest card only moved when a screen happened to remount after its `staleTime`.

Recording an activity now schedules a debounced refresh. The delay matches how long the backend actually takes to credit a chain action, rather than firing a few seconds later against unchanged numbers, which would mark them fresh for the query's `staleTime` and prevent the real update from being picked up.

One deliberate difference from the website: votes are not excluded. The website skips them because its debounce is short enough that fast feed voting would fan out requests. At this delay a voting burst collapses into a single request after the user stops, and the daily vote quest is one people watch.

## Verification

```
yarn test:ci    51 passed, 1 skipped (52 suites), 746 passed, 1 skipped (747 tests)
yarn typecheck  0 errors (baseline 0)
yarn lint       0 errors
```

New tests cover the debounce: no request at 10s, one after the real delay, a burst of three coalesced into one, a leading `@` stripped from the key, and a no-op without a username.

Not covered by tests: the `AppState` to `focusManager` wiring itself, which needs a device. Worth a manual pass on the Notifications leaderboard tab (background the app, wait, return, board updates without a pull) and on /perks after posting.

## Related

The server-side half of the badge staleness is ecency/esync-py#27, and the crediting delay is ecency/ePoints#51. The composer warning for short replies is #3473, which waits on the SDK release from ecency/vision-web#1394.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboard and quest information now refresh automatically when you return to the app or browser window.
  * Quest progress updates after user activity are scheduled to appear automatically once backend processing is complete.
  * Rapid quest refresh requests are coordinated to reduce unnecessary updates.

* **Bug Fixes**
  * Improved synchronization of leaderboard and quest data after app inactivity and resumed use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->