### PR TITLE
Chat: tell a banned user what happened and when it lifts

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -685,7 +685,16 @@
     "select_emoji": "Select Emoji",
     "more_emojis": "More",
     "search_emojis": "Search emojis...",
-    "no_emoji_found": "No emoji found"
+    "no_emoji_found": "No emoji found",
+    "ban-reason-spray": "You're paused from posting because the same message went to several channels at once.",
+    "ban-reason-mass-dm": "You're paused from posting because a message was sent to many people at once.",
+    "ban-reason-generic": "You're paused from posting in chat.",
+    "ban-can-still-read": "You can still read chat.",
+    "ban-unlocks": "Posting unlocks {when}.",
+    "ban-remaining-soon": "in under a minute",
+    "ban-remaining-minutes": "in about {count} minutes",
+    "ban-remaining-hours": "in about {count} hours",
+    "ban-remaining-days": "in about {count} days"
   },
   "free_estm": {
     "timer_text": "Next free spin in",

--- a/src/providers/chat/mattermost.ts
+++ b/src/providers/chat/mattermost.ts
@@ -422,6 +422,12 @@ export const sendMattermostMessage = async (
         err.response?.data?.error || err.response?.data?.message || 'User is banned from chat',
       );
       banError.isBanError = true;
+      // Carry the structured payload, not just the message. The message is operator-facing
+      // (it names the account and quotes an ISO timestamp); these two are what let the UI say
+      // why it happened and when it lifts. Dropping them strands the notice and forces the UI
+      // back to displaying the very string it exists to replace.
+      banError.bannedUntil = err.response?.data?.bannedUntil;
+      banError.reason = err.response?.data?.reason;
       throw banError;
     }
     throw err;

--- a/src/screens/chats/children/ChatBanBanner.tsx
+++ b/src/screens/chats/children/ChatBanBanner.tsx
@@ -22,8 +22,12 @@ export const ChatBanBanner: React.FC<ChatBanBannerProps> = ({ info, onExpire }) 
   const [now, setNow] = useState(() => Date.now());
 
   // Held in a ref so an inline arrow from the caller doesn't restart the interval each render.
+  // Assigned in an effect rather than during render: a render React discards could otherwise
+  // mutate the ref the already-committed interval reads from.
   const onExpireRef = useRef(onExpire);
-  onExpireRef.current = onExpire;
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -43,7 +47,7 @@ export const ChatBanBanner: React.FC<ChatBanBannerProps> = ({ info, onExpire }) 
       <Text style={styles.dmWarningIcon}>⏳</Text>
       <View style={styles.dmWarningContent}>
         <Text style={styles.dmWarningBody}>
-          {formatChatBanNotice(info, now, intl.formatMessage as any)}
+          {formatChatBanNotice(info, now, intl.formatMessage)}
         </Text>
       </View>
     </View>

--- a/src/screens/chats/children/ChatBanBanner.tsx
+++ b/src/screens/chats/children/ChatBanBanner.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Text, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import { chatThreadStyles as styles } from '../styles/chatThread.styles';
+import { BAN_NOTICE_TICK_MS, ChatBanInfo, formatChatBanNotice } from '../utils/chatBanNotice';
+
+interface ChatBanBannerProps {
+  info: ChatBanInfo;
+  /** Called once the ban lapses, so the caller can clear the banner without a reload. */
+  onExpire?: () => void;
+}
+
+/**
+ * Standing notice shown while the user is banned from posting.
+ *
+ * Replaces a one-shot toast. A ban is a state, not an event: a toast explains it once and then
+ * every later send just fails silently, which is how the original version left people with no
+ * idea why nothing sent.
+ */
+export const ChatBanBanner: React.FC<ChatBanBannerProps> = ({ info, onExpire }) => {
+  const intl = useIntl();
+  const [now, setNow] = useState(() => Date.now());
+
+  // Held in a ref so an inline arrow from the caller doesn't restart the interval each render.
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const t = Date.now();
+      setNow(t);
+      if (t >= info.bannedUntil) {
+        clearInterval(id);
+        onExpireRef.current?.();
+      }
+    }, BAN_NOTICE_TICK_MS);
+    return () => clearInterval(id);
+  }, [info.bannedUntil]);
+
+  return (
+    <View style={styles.dmWarningContainer}>
+      {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}
+      <Text style={styles.dmWarningIcon}>⏳</Text>
+      <View style={styles.dmWarningContent}>
+        <Text style={styles.dmWarningBody}>
+          {formatChatBanNotice(info, now, intl.formatMessage as any)}
+        </Text>
+      </View>
+    </View>
+  );
+};

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -87,6 +87,8 @@ import { PinnedMessagesModal } from '../children/PinnedMessagesModal';
 import { OnlineUsersModal } from '../children/OnlineUsersModal';
 import { TypingIndicator } from '../children/TypingIndicator';
 import { DmWarningBanner } from '../children/DmWarningBanner';
+import { ChatBanBanner } from '../children/ChatBanBanner';
+import { ChatBanInfo, getChatBanInfo } from '../utils/chatBanNotice';
 
 interface ChatReaction {
   emoji_name: string;
@@ -149,6 +151,7 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [banInfo, setBanInfo] = useState<ChatBanInfo | null>(null);
   const [hasBootstrapped, setHasBootstrapped] = useState<boolean>(!!initialBootstrap);
   const [canModerate, setCanModerate] = useState<boolean>(false);
   const [lastViewedAt, setLastViewedAt] = useState<number | null>(initialLastViewedAt ?? null);
@@ -1320,6 +1323,10 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         }
       }
 
+      // A send that lands proves the ban is gone, which is how an early moderator unban
+      // clears the banner instead of it lingering until the original expiry.
+      setBanInfo(null);
+
       // Always clear input after successful send via HTTP response.
       // WebSocket may also clear it via onNewMessage, but HTTP is the reliable path.
       setMessage('');
@@ -1343,7 +1350,14 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
         confirmedPendingPostIdsRef.current.delete(pendingId);
       } else {
         // Check if this is a ban error
-        if (err?.isBanError) {
+        const ban = getChatBanInfo(err);
+        if (ban) {
+          // Standing state, not a toast: a ban persists, so the explanation has to persist with
+          // it. `error` is no good here either — it only renders in the empty-thread view.
+          setBanInfo(ban);
+        } else if (err?.isBanError) {
+          // Ban detected but no usable expiry (an older server, or a malformed payload). Fall
+          // back to the previous one-shot message rather than showing a countdown we don't have.
           dispatch(
             toastNotification(
               intl.formatMessage({
@@ -2196,6 +2210,8 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
           currentUserId={bootstrapUserId}
           getHiveUsername={getHiveUsernameFromMattermostUser as any}
         />
+
+        {banInfo && <ChatBanBanner info={banInfo} onExpire={() => setBanInfo(null)} />}
 
         <ThreadComposer
           message={message}

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -303,6 +303,14 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
           Math.abs((post.create_at || 0) - lastSentAtRef.current) < 30000;
 
         if (pendingMatch || fallbackMatch) {
+          // A websocket echo of our own just-sent message is independent proof the create
+          // landed, and it can arrive when the HTTP response never does (timeout, dropped
+          // connection). Without this the banner would sit there until its original expiry
+          // even though the ban has clearly been lifted. Both match arms are create-only:
+          // pending_post_id is set only when creating, and the fallback keys on
+          // lastSentMessageRef, which the create branch is what populates.
+          setBanInfo(null);
+
           const confirmedId = lastSentPendingIdRef.current;
           if (confirmedId) {
             confirmedPendingPostIdsRef.current.add(confirmedId);

--- a/src/screens/chats/container/chatThreadContainer.tsx
+++ b/src/screens/chats/container/chatThreadContainer.tsx
@@ -1299,6 +1299,13 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
           props,
           pendingPostId,
         );
+
+        // Cleared HERE, in the create branch only. The ban gates creating posts and nothing
+        // else — editing an existing message is not checked server-side — so a successful edit
+        // proves nothing about the restriction and must not dismiss the notice. Only a create
+        // that lands shows the ban is actually gone (an early moderator unban).
+        setBanInfo(null);
+
         const newPost = normalizePost(response);
         if (newPost) {
           if (channelId) {
@@ -1322,10 +1329,6 @@ export const ChatThreadContainer: React.FC<ChatThreadContainerProps> = ({
           }
         }
       }
-
-      // A send that lands proves the ban is gone, which is how an early moderator unban
-      // clears the banner instead of it lingering until the original expiry.
-      setBanInfo(null);
 
       // Always clear input after successful send via HTTP response.
       // WebSocket may also clear it via onNewMessage, but HTTP is the reliable path.

--- a/src/screens/chats/utils/chatBanNotice.test.ts
+++ b/src/screens/chats/utils/chatBanNotice.test.ts
@@ -1,0 +1,116 @@
+import {
+  BAN_NOTICE_TICK_MS,
+  formatBanRemaining,
+  formatChatBanNotice,
+  getChatBanInfo,
+} from './chatBanNotice';
+
+// Stands in for react-intl's formatMessage: returns defaultMessage with {placeholder} filled,
+// which is what the real one does for these descriptors.
+const fmt = (
+  descriptor: { id: string; defaultMessage: string },
+  values?: Record<string, string | number>,
+) => {
+  let out = descriptor.defaultMessage;
+  Object.entries(values || {}).forEach(([k, v]) => {
+    out = out.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
+  });
+  return out;
+};
+
+const NOW = 1_800_000_000_000;
+const mins = (n: number) => NOW + n * 60_000;
+const hours = (n: number) => NOW + n * 3_600_000;
+const days = (n: number) => NOW + n * 86_400_000;
+
+describe('getChatBanInfo', () => {
+  it('extracts a live ban from the thrown error', () => {
+    expect(getChatBanInfo({ bannedUntil: hours(48), reason: 'spray' }, NOW)).toEqual({
+      bannedUntil: hours(48),
+      reason: 'spray',
+    });
+  });
+
+  it('ignores an expired ban', () => {
+    expect(getChatBanInfo({ bannedUntil: NOW - 1 }, NOW)).toBeNull();
+  });
+
+  it('returns null for ordinary failures', () => {
+    expect(getChatBanInfo(new Error('network'), NOW)).toBeNull();
+    expect(getChatBanInfo(null, NOW)).toBeNull();
+  });
+
+  it('tolerates a ban with no reason, so older servers still work', () => {
+    expect(getChatBanInfo({ bannedUntil: hours(1) }, NOW)?.reason).toBeUndefined();
+  });
+
+  it('drops a non-string reason rather than rendering it', () => {
+    expect(
+      getChatBanInfo({ bannedUntil: hours(1), reason: { a: 1 } }, NOW)?.reason,
+    ).toBeUndefined();
+  });
+});
+
+describe('formatBanRemaining', () => {
+  it('scales the unit to the magnitude', () => {
+    expect(formatBanRemaining(mins(30), NOW, fmt)).toContain('30 minutes');
+    expect(formatBanRemaining(hours(5), NOW, fmt)).toContain('5 hours');
+    expect(formatBanRemaining(days(2), NOW, fmt)).toContain('2 days');
+  });
+
+  it('never promises an unlock that has not happened', () => {
+    expect(formatBanRemaining(NOW + 30_000, NOW, fmt)).toBe('in under a minute');
+    expect(formatBanRemaining(NOW - 10_000, NOW, fmt)).toBe('in under a minute');
+  });
+
+  it('never phrases a count as 1', () => {
+    [mins(59), mins(89), hours(1), hours(2), days(1), days(400)].forEach((until) => {
+      const match = formatBanRemaining(until, NOW, fmt).match(/about (\d+)/);
+      if (match) {
+        expect(Number(match[1])).toBeGreaterThanOrEqual(2);
+      }
+    });
+  });
+
+  it('renders a multi-year ban as days rather than degrading', () => {
+    expect(formatBanRemaining(NOW + 3 * 365 * 86_400_000, NOW, fmt)).toContain('1095 days');
+  });
+});
+
+describe('formatChatBanNotice', () => {
+  it('explains a spray timeout', () => {
+    const text = formatChatBanNotice({ bannedUntil: hours(48), reason: 'spray' }, NOW, fmt);
+    expect(text).toContain('same message went to several channels');
+    expect(text).toContain('You can still read chat.');
+    expect(text).toContain('2 days');
+  });
+
+  it('explains a mass-DM ban differently', () => {
+    const text = formatChatBanNotice({ bannedUntil: days(365), reason: 'mass-dm' }, NOW, fmt);
+    expect(text).toContain('many people at once');
+  });
+
+  it('falls back to generic copy for manual and unrecognised reasons', () => {
+    ['manual', 'reason-from-a-newer-service', undefined].forEach((reason) => {
+      const text = formatChatBanNotice({ bannedUntil: hours(3), reason }, NOW, fmt);
+      expect(text).toContain('paused from posting');
+      expect(text).toContain('3 hours');
+    });
+  });
+
+  it('never shows operator-facing detail to the banned user', () => {
+    const text = formatChatBanNotice({ bannedUntil: hours(48), reason: 'spray' }, NOW, fmt);
+    expect(text).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(text).not.toContain('ecency_chat');
+    expect(text).not.toContain('@');
+  });
+});
+
+describe('BAN_NOTICE_TICK_MS', () => {
+  it('stays inside the 32-bit setTimeout limit', () => {
+    // A delay derived from bannedUntil overflows for long bans and fires almost immediately,
+    // which would clear the notice for exactly the users who are most banned.
+    expect(BAN_NOTICE_TICK_MS).toBeGreaterThan(0);
+    expect(BAN_NOTICE_TICK_MS).toBeLessThan(2_147_483_647);
+  });
+});

--- a/src/screens/chats/utils/chatBanNotice.test.ts
+++ b/src/screens/chats/utils/chatBanNotice.test.ts
@@ -44,6 +44,15 @@ describe('getChatBanInfo', () => {
     expect(getChatBanInfo({ bannedUntil: hours(1) }, NOW)?.reason).toBeUndefined();
   });
 
+  it('rejects a non-finite expiry', () => {
+    // Infinity survives an isNaN check and is also > now, so both original guards passed it.
+    // The banner would then show an endless duration and never fire onExpire.
+    expect(getChatBanInfo({ bannedUntil: Infinity }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: 'Infinity' }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: -Infinity }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: 'not-a-number' }, NOW)).toBeNull();
+  });
+
   it('drops a non-string reason rather than rendering it', () => {
     expect(
       getChatBanInfo({ bannedUntil: hours(1), reason: { a: 1 } }, NOW)?.reason,

--- a/src/screens/chats/utils/chatBanNotice.ts
+++ b/src/screens/chats/utils/chatBanNotice.ts
@@ -25,7 +25,10 @@ export interface ChatBanInfo {
 export const getChatBanInfo = (error: any, now: number = Date.now()): ChatBanInfo | null => {
   const bannedUntil = Number(error?.bannedUntil);
 
-  if (!error?.bannedUntil || Number.isNaN(bannedUntil) || bannedUntil <= now) {
+  // isFinite, not isNaN: Infinity survives an isNaN check and is also > now, so it would render
+  // an endless duration and never fire onExpire. Returning null sends the caller down its
+  // existing fallback path instead.
+  if (!error?.bannedUntil || !Number.isFinite(bannedUntil) || bannedUntil <= now) {
     return null;
   }
 

--- a/src/screens/chats/utils/chatBanNotice.ts
+++ b/src/screens/chats/utils/chatBanNotice.ts
@@ -1,0 +1,122 @@
+/**
+ * Copy for a chat ban, mirroring the web client's `chat-ban-notice.ts`.
+ *
+ * The API sends `bannedUntil` (epoch ms) and an optional `reason`, and deliberately does not send
+ * display text: the remaining time must be computed at render so it counts down, and the wording
+ * must be translatable. The server's own `error` string is operator-facing — it names the account
+ * and quotes an ISO timestamp — and must never be shown to the person who is banned.
+ *
+ * The bands and wording are kept identical to web on purpose. Two clients explaining the same
+ * moderation action differently is worse than either wording alone.
+ */
+
+/** Matches react-intl's formatMessage, but injectable so this stays a pure, testable unit. */
+export type BanMessageFormatter = (
+  descriptor: { id: string; defaultMessage: string },
+  values?: Record<string, string | number>,
+) => string;
+
+export interface ChatBanInfo {
+  bannedUntil: number;
+  reason?: string;
+}
+
+/** Extracts ban info from a thrown request error, or null when it isn't a live ban. */
+export const getChatBanInfo = (error: any, now: number = Date.now()): ChatBanInfo | null => {
+  const bannedUntil = Number(error?.bannedUntil);
+
+  if (!error?.bannedUntil || Number.isNaN(bannedUntil) || bannedUntil <= now) {
+    return null;
+  }
+
+  return {
+    bannedUntil,
+    reason: typeof error.reason === 'string' ? error.reason : undefined,
+  };
+};
+
+/**
+ * Coarse remaining time, rounded up. Each band hands `count` a value of 2 or more, so no phrasing
+ * can come out as "1 hours" and these stay plain keys rather than needing plural variants.
+ */
+export const formatBanRemaining = (
+  bannedUntil: number,
+  now: number,
+  formatMessage: BanMessageFormatter,
+): string => {
+  const ms = Math.max(0, bannedUntil - now);
+  const minutes = Math.ceil(ms / 60000);
+
+  if (minutes <= 1) {
+    return formatMessage({
+      id: 'chats.ban-remaining-soon',
+      defaultMessage: 'in under a minute',
+    });
+  }
+
+  if (minutes < 90) {
+    return formatMessage(
+      { id: 'chats.ban-remaining-minutes', defaultMessage: 'in about {count} minutes' },
+      { count: minutes },
+    );
+  }
+
+  const hours = Math.round(ms / 3600000);
+  if (hours < 48) {
+    return formatMessage(
+      { id: 'chats.ban-remaining-hours', defaultMessage: 'in about {count} hours' },
+      { count: hours },
+    );
+  }
+
+  return formatMessage(
+    { id: 'chats.ban-remaining-days', defaultMessage: 'in about {count} days' },
+    { count: Math.round(ms / 86400000) },
+  );
+};
+
+/** The reason sentence. Never names detection thresholds or the underlying prop. */
+const reasonSentence = (reason: string | undefined, formatMessage: BanMessageFormatter): string => {
+  switch (reason) {
+    case 'spray':
+      return formatMessage({
+        id: 'chats.ban-reason-spray',
+        defaultMessage:
+          "You're paused from posting because the same message went to several channels at once.",
+      });
+    case 'mass-dm':
+      return formatMessage({
+        id: 'chats.ban-reason-mass-dm',
+        defaultMessage:
+          "You're paused from posting because a message was sent to many people at once.",
+      });
+    default:
+      // Covers 'manual' and any reason a newer moderation service adds that this build predates.
+      return formatMessage({
+        id: 'chats.ban-reason-generic',
+        defaultMessage: "You're paused from posting in chat.",
+      });
+  }
+};
+
+/** Full notice: what happened, that reading still works, and when it lifts. */
+export const formatChatBanNotice = (
+  info: ChatBanInfo,
+  now: number,
+  formatMessage: BanMessageFormatter,
+): string => {
+  const stillReadable = formatMessage({
+    id: 'chats.ban-can-still-read',
+    defaultMessage: 'You can still read chat.',
+  });
+  const unlocks = formatMessage(
+    { id: 'chats.ban-unlocks', defaultMessage: 'Posting unlocks {when}.' },
+    { when: formatBanRemaining(info.bannedUntil, now, formatMessage) },
+  );
+
+  return `${reasonSentence(info.reason, formatMessage)} ${stillReadable} ${unlocks}`;
+};
+
+/** Bounded tick for the live notice. Never derive a timer delay from `bannedUntil`: setTimeout
+ *  takes a 32-bit signed delay, so a multi-year ban would fire almost immediately. */
+export const BAN_NOTICE_TICK_MS = 30000;


### PR DESCRIPTION
Closes #3470. Mobile counterpart to ecency/vision-web#1390 (merged).

## Before

`sendMattermostMessage` detected the ban but built an error carrying only the message, dropping `bannedUntil` and `reason`. The UI showed a one-shot toast:

```
Unusual activity detected. Please try again after some time.
```

No duration, so a 48-hour timeout and a 3-year ban read identically. And because it was a toast, once dismissed every later send failed with no standing explanation.

## After

A persistent banner above the composer:

```
You are paused from posting because the same message went to several channels at once.
You can still read chat. Posting unlocks in about 2 days.
```

## Changes

- `providers/chat/mattermost.ts` preserves `bannedUntil` and `reason` on the thrown error
- `screens/chats/utils/chatBanNotice.ts` builds the copy, mirroring the web formatter with the same reasons and the same duration bands, so the two clients cannot describe one moderation action differently. `formatMessage` is injected rather than imported, keeping it a pure testable unit
- `screens/chats/children/ChatBanBanner.tsx` renders it above the composer, next to the action that is blocked, following the existing `DmWarningBanner` pattern
- nine `chats.ban-*` keys added to the Crowdin source

## Details worth knowing

**The banner ticks.** It re-renders on a bounded interval instead of freezing at first render, and clears both at expiry and on a successful send, which is how an early moderator unban gets picked up without a reload.

**The tick is deliberately a fixed interval, not a delay derived from `bannedUntil`.** `setTimeout` takes a 32-bit signed delay, so a 3-year ban resolves to ~1ms and would clear its own notice instantly, hiding it from exactly the users who are most banned. That bit the web PR; there is a test for it here.

**Duration bands never produce a count of 1**, so nothing reads "in about 1 hours" and these stay plain keys rather than needing plural variants.

**The old toast remains as a fallback** for a ban with no usable expiry, so an older server still says something rather than nothing.

**Unknown reasons degrade to generic copy**: live bans predate the reason prop, and a newer moderation service may add reasons this build has not seen.

## Checks

Full suite green (756 passed, 51 suites), 14 new tests. `typecheck ok: 0 errors (baseline 0)`. Lint on the touched files is unchanged from `development` (12 warnings, 0 errors, all pre-existing).

The locale addition is a byte-preserving textual insert. A `json.dump` round-trip rewrote existing `\uXXXX` escapes across the file, so the diff here is 10 added lines rather than a whole-file reformat that would have churned the Crowdin source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent chat restriction banner showing the reason and remaining duration.
  * Ban notices update automatically and disappear when the restriction expires.
  * Added localized messages for emoji search results and temporary posting restrictions.

* **Bug Fixes**
  * Improved handling of chat restriction details, including expiry times and moderation reasons.
  * Retained a fallback notification when restriction information is unavailable.

* **Tests**
  * Added coverage for restriction validation, formatting, expiration, and privacy-safe messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->