### PR TITLE
fix(wallet): load HIVE/HBD transaction history again

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.79",
+    "@ecency/sdk": "^2.3.80",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1255,6 +1255,8 @@
     "checkin_desc": "Checking in regularly gives you 0.25 points.",
     "fill_transfer_from_savings": "Savings Executed",
     "activities": "Activities",
+    "no_activities": "No transactions yet",
+    "activities_failed": "Could not load transactions. Pull down to retry.",
     "tap_update": "Tap to update",
     "mining_lottery": "Lottery Won",
     "checkin": "Check-in",

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { unionBy, get } from 'lodash';
 import { RecurrentTransfer } from 'providers/hive/hive.types';
@@ -11,13 +11,20 @@ import {
   getCollateralizedConversionRequestsQueryOptions,
   getRecurrentTransfersQueryOptions,
   getOpenOrdersQueryOptions,
-  getTransactionsInfiniteQueryOptions,
+  getHiveAssetTransactionsQueryOptions,
+  getHbdAssetTransactionsQueryOptions,
+  getHivePowerAssetTransactionsQueryOptions,
   getPointsQueryOptions,
   getPortfolioQueryOptions,
   getHiveEngineTokenTransactions,
   useBroadcastMutation,
   buildRecurrentTransferOp,
 } from '@ecency/sdk';
+import {
+  getHistoryOpsForSymbol,
+  getNextHistoryPageParam,
+  matchesAssetTicker,
+} from '../../../utils/walletHistory';
 import { ASSET_IDS } from '../../../constants/defaultAssets';
 import { resolvePointType } from '../../../constants/options/points';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
@@ -57,6 +64,11 @@ interface RecurrentTransferPayload {
 }
 
 const ACTIVITIES_FETCH_LIMIT = 50;
+
+// A page whose rows are all filtered out client-side leaves the list empty, and an
+// empty list is never scrolled, so `onEndReached` never fires to pull the next page.
+// Auto-advance at most this many pages while nothing renders.
+const MAX_AUTO_ADVANCE_PAGES = 5;
 
 /** hook used to return user drafts */
 export const useAssetsQuery = ({ onlyEnabled = true }: { onlyEnabled?: boolean } = {}) => {
@@ -360,9 +372,38 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
   });
 
   // Only fetch Hive transactions for native Hive tokens (HIVE, HBD, HP)
-  // External chain tokens (BNB, ETH, etc.) have no transaction history API
+  // External chain tokens (BNB, ETH, etc.) have no transaction history API.
+  //
+  // History comes from `condenser_api.get_account_history` with a server-side
+  // operation bitmask. The previous `getTransactionsInfiniteQueryOptions` path called
+  // hafah's REST `/accounts/{name}/operations` with a 30-op-type filter, which on an
+  // account with a large history takes 2-28s server-side (and answers HTTP 500
+  // "canceling statement due to statement timeout" on some nodes) against the 10s
+  // client ceiling set in `sdk-config.ts`, so the list simply never loaded. The same
+  // filter over RPC answers in well under a second.
+  const chainQueryOptions = useMemo(() => {
+    const historyOps = getHistoryOpsForSymbol(symbol);
+    const name = username ?? '';
+
+    switch (symbol) {
+      case 'HBD':
+        return getHbdAssetTransactionsQueryOptions(name, ACTIVITIES_FETCH_LIMIT, historyOps);
+      case 'HP':
+        return getHivePowerAssetTransactionsQueryOptions(name, ACTIVITIES_FETCH_LIMIT, historyOps);
+      default:
+        return getHiveAssetTransactionsQueryOptions(name, ACTIVITIES_FETCH_LIMIT, historyOps);
+    }
+  }, [symbol, username]);
+
   const chainQuery = useInfiniteQuery({
-    ...getTransactionsInfiniteQueryOptions(username ?? '', ACTIVITIES_FETCH_LIMIT),
+    ...chainQueryOptions,
+    // The SDK seeds `initialData: { pages: [], pageParams: [] }` for the web's
+    // server-prefetched wallet pages. Mobile's client defaults to staleTime 60s, so
+    // that empty seed reads as fresh data and suppresses the very first fetch.
+    initialData: undefined,
+    // See getNextHistoryPageParam: the SDK cursor reads the newest row, not the oldest,
+    // so it advances one operation per page and never terminates.
+    getNextPageParam: getNextHistoryPageParam,
     enabled: !!username && isHive,
   });
 
@@ -384,8 +425,12 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
     getNextPageParam: (lastPage, pages) => (lastPage?.length ? pages.length : undefined),
   });
 
+  // Bounded auto-advance counter, declared here so `_refresh` can clear it.
+  const autoAdvancedRef = useRef(0);
+
   const _refresh = async () => {
     setIsRefreshing(true);
+    autoAdvancedRef.current = 0;
     if (isPoints) {
       await pointsQuery.refetch();
     } else if (isEngine) {
@@ -434,10 +479,10 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
       );
     }
 
-    // SDK pages have shape { entries: Transaction[], currentPage }; flatten the
-    // entries arrays so each `tx` is the normalized operation object that
-    // groomingTransactionData understands (it also tolerates the legacy array form).
-    // Defensively handle both shapes in case a cached/legacy page is an array.
+    // Each SDK page is a Transaction[] whose items are flat operation objects
+    // ({ num, type, timestamp, ...opValue }) that groomingTransactionData understands.
+    // Older cached pages may still hold the { entries } wrapper or the legacy
+    // [trxIndex, { op }] tuple form, so tolerate all three.
     const _chainPages = (chainQuery.data as any)?.pages as
       | Array<unknown[] | { entries?: unknown[] }>
       | undefined;
@@ -454,7 +499,7 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
       groomingTransactionData(item, globalProps.hivePerMVests),
     );
 
-    return activities.filter((item) => item && item.value && item.value.includes(symbol));
+    return activities.filter((item) => matchesAssetTicker(item, symbol));
   }, [
     pointsQuery.data?.transactions,
     (chainQuery.data as any)?.pages,
@@ -465,16 +510,38 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
     symbol,
   ]);
 
+  // A page can be filtered down to nothing (an HBD-only page on the HIVE tab, a run of
+  // curation rewards on HBD), leaving an empty list that is never scrolled and so never
+  // fires `onEndReached` to pull the next page. Walk forward a bounded number of pages
+  // while nothing renders instead of showing the user an empty history.
+  useEffect(() => {
+    autoAdvancedRef.current = 0;
+  }, [symbol, username]);
+
+  useEffect(() => {
+    if (!isHive || _data.length > 0) {
+      return;
+    }
+    if (!chainQuery.hasNextPage || chainQuery.isFetching) {
+      return;
+    }
+    if (autoAdvancedRef.current >= MAX_AUTO_ADVANCE_PAGES) {
+      return;
+    }
+
+    autoAdvancedRef.current += 1;
+    chainQuery.fetchNextPage();
+  }, [isHive, _data.length, chainQuery.hasNextPage, chainQuery.isFetching]);
+
+  const activeQuery = isPoints ? pointsQuery : isEngine ? engineQuery : chainQuery;
+
   return {
     data: _data,
     isRefreshing,
-    isLoading: isPoints
-      ? pointsQuery.isLoading || pointsQuery.isFetching
-      : isEngine
-      ? engineQuery.isLoading || engineQuery.isFetching
-      : isHive
-      ? chainQuery.isLoading || chainQuery.isFetching
-      : false,
+    isLoading:
+      isPoints || isEngine || isHive ? activeQuery.isLoading || activeQuery.isFetching : false,
+    isError: isPoints || isEngine || isHive ? activeQuery.isError : false,
+    error: isPoints || isEngine || isHive ? activeQuery.error : null,
     fetchNextPage: _fetchNextPage,
     refresh: _refresh,
   };
@@ -485,10 +552,15 @@ export const useRecurringActivitesQuery = (coinId: string) => {
   const currentAccount = useAppSelector(selectCurrentAccount);
   const username = currentAccount?.name;
 
+  // Every caller now passes the portfolio symbol ('HIVE'), not the legacy asset id
+  // ('hive'), so gating on ASSET_IDS.HIVE alone left this query permanently disabled
+  // and the coin summary stuck on "0" recurrent transfers. Accept both spellings.
+  const isHiveAsset = coinId === ASSET_IDS.HIVE || coinId === 'HIVE';
+
   // Always call useQuery (Rules of Hooks) - use enabled to control execution
   const query = useQuery({
     ...getRecurrentTransfersQueryOptions(username || ''),
-    enabled: coinId === ASSET_IDS.HIVE && !!username, // Only fetch for HIVE and when username exists
+    enabled: isHiveAsset && !!username, // Only fetch for HIVE and when username exists
   });
 
   const totalAmount = useMemo(() => {

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -560,6 +560,18 @@ export const useRecurringActivitesQuery = (coinId: string) => {
   const query = useQuery({
     ...getRecurrentTransfersQueryOptions(username || ''),
     enabled: isHiveAsset && !!username, // Only fetch for HIVE and when username exists
+    // The SDK query is scoped to the account, not to an asset, so it returns every
+    // schedule the account has. The total below sums bare `parseFloat` values and the
+    // summary labels them HIVE, so an account with 1 HIVE and 10 HBD scheduled read as
+    // "11 HIVE" and the modal listed the HBD schedules under HIVE. Latent until the
+    // gate above started matching.
+    select: (data) =>
+      data.filter(
+        (item) =>
+          String(item.amount || '')
+            .trim()
+            .split(/\s+/)[1] === 'HIVE',
+      ),
   });
 
   const totalAmount = useMemo(() => {

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -20,11 +20,7 @@ import {
   useBroadcastMutation,
   buildRecurrentTransferOp,
 } from '@ecency/sdk';
-import {
-  getHistoryOpsForSymbol,
-  getNextHistoryPageParam,
-  matchesAssetTicker,
-} from '../../../utils/walletHistory';
+import { getHistoryOpsForSymbol, matchesAssetTicker } from '../../../utils/walletHistory';
 import { ASSET_IDS } from '../../../constants/defaultAssets';
 import { resolvePointType } from '../../../constants/options/points';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
@@ -381,6 +377,9 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
   // "canceling statement due to statement timeout" on some nodes) against the 10s
   // client ceiling set in `sdk-config.ts`, so the list simply never loaded. The same
   // filter over RPC answers in well under a second.
+  //
+  // Pagination is the SDK's: 2.3.80 fixed the cursor to walk back from the oldest row
+  // on the page (a page arrives in ascending `num`), so no local override is needed.
   const chainQueryOptions = useMemo(() => {
     const historyOps = getHistoryOpsForSymbol(symbol);
     const name = username ?? '';
@@ -397,13 +396,13 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
 
   const chainQuery = useInfiniteQuery({
     ...chainQueryOptions,
-    // The SDK seeds `initialData: { pages: [], pageParams: [] }` for the web's
-    // server-prefetched wallet pages. Mobile's client defaults to staleTime 60s, so
-    // that empty seed reads as fresh data and suppresses the very first fetch.
+    // Guard, not a workaround. These options used to seed
+    // `initialData: { pages: [], pageParams: [] }` for the web's server-prefetched
+    // pages; against this client's staleTime of 60s that empty seed reads as fresh
+    // data and suppresses the very first fetch, so the history renders empty and
+    // nothing reports an error. @ecency/sdk 2.3.80 dropped it, and no SDK test pins
+    // its absence, so keep this until one does.
     initialData: undefined,
-    // See getNextHistoryPageParam: the SDK cursor reads the newest row, not the oldest,
-    // so it advances one operation per page and never terminates.
-    getNextPageParam: getNextHistoryPageParam,
     enabled: !!username && isHive,
   });
 

--- a/src/screens/assetDetails/children/activitiesList.tsx
+++ b/src/screens/assetDetails/children/activitiesList.tsx
@@ -16,6 +16,7 @@ interface ActivitiesListProps {
   completedActivities: CoinActivity[];
   refreshing: boolean;
   loading: boolean;
+  failed: boolean;
   activitiesEnabled: boolean;
   onEndReached: () => void;
   onRefresh: () => void;
@@ -26,6 +27,7 @@ export const ActivitiesList = ({
   header,
   loading,
   refreshing,
+  failed,
   completedActivities,
   pendingActivities,
   activitiesEnabled,
@@ -74,8 +76,11 @@ export const ActivitiesList = ({
 
   const sections = [];
 
+  // Explicit keys: without them the pending section appearing shifts the completed
+  // section's identity and re-mounts every visible row.
   if (pendingActivities && pendingActivities.length) {
     sections.push({
+      key: 'pending',
       title: intl.formatMessage({ id: 'wallet.pending_requests' }),
       data: pendingActivities,
     });
@@ -83,6 +88,7 @@ export const ActivitiesList = ({
 
   if (activitiesEnabled) {
     sections.push({
+      key: 'completed',
       title: intl.formatMessage({ id: 'wallet.activities' }),
       data: completedActivities || [],
     });
@@ -99,26 +105,48 @@ export const ActivitiesList = ({
     />
   );
 
+  // A failed fetch used to be indistinguishable from an empty history: both rendered a
+  // bare header with nothing under it. Only claim "no transactions" once a request has
+  // actually settled without error.
+  const _renderFooter = () => {
+    if (loading) {
+      return (
+        <ActivityIndicator
+          color={EStyleSheet.value('$primaryBlue')}
+          style={styles.activitiesFooterIndicator}
+        />
+      );
+    }
+
+    if (!activitiesEnabled || completedActivities?.length) {
+      return null;
+    }
+
+    return (
+      <Text style={styles.activitiesPlaceholder}>
+        {intl.formatMessage({ id: failed ? 'wallet.activities_failed' : 'wallet.no_activities' })}
+      </Text>
+    );
+  };
+
   return (
     <SectionList
       style={styles.list}
       contentContainerStyle={styles.listContent}
       sections={sections}
       renderItem={_renderActivityItem}
-      keyExtractor={(item, index) => `activity_item_${index}_${item.created}`}
+      // `created` alone repeats across ops mined in the same block, and the index alone
+      // shifts as pages prepend, so key on the on-chain identity when there is one.
+      keyExtractor={(item, index) =>
+        `activity_item_${item.engineTrxId ?? item.trxIndex ?? index}_${item.created}`
+      }
       renderSectionHeader={({ section: { title } }) => (
         <Text style={styles.textActivities}>{title}</Text>
       )}
-      ListFooterComponent={
-        loading ? (
-          <ActivityIndicator
-            color={EStyleSheet.value('$primaryBlue')}
-            style={styles.activitiesFooterIndicator}
-          />
-        ) : null
-      }
+      ListFooterComponent={_renderFooter()}
       ListHeaderComponent={header}
       refreshControl={_refreshControl}
+      onEndReachedThreshold={0.5}
       onEndReached={() => {
         onEndReached();
       }}

--- a/src/screens/assetDetails/children/children.styles.ts
+++ b/src/screens/assetDetails/children/children.styles.ts
@@ -132,6 +132,13 @@ export default EStyleSheet.create({
     marginVertical: 16,
   } as ViewStyle,
 
+  activitiesPlaceholder: {
+    color: '$primaryDarkText',
+    fontSize: 14,
+    textAlign: 'center',
+    paddingVertical: 24,
+  } as TextStyle,
+
   delegationsModal: {
     flex: 1,
     backgroundColor: '$primaryBackgroundColor',

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -78,7 +78,17 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
     }
   }, [assetsQuery.data]);
 
+  // The AppState listener is registered once, so it would capture the first render's
+  // `_fetchDetails` and with it a permanently-false `isRefreshing`/`isLoading`. Route
+  // it through a ref so foregrounding refreshes against current query state instead of
+  // restarting an in-flight fetch.
+  const fetchDetailsRef = useRef<(refresh?: boolean) => void>(() => {});
+
   // side-effects
+  useEffect(() => {
+    fetchDetailsRef.current = _fetchDetails;
+  });
+
   useEffect(() => {
     _fetchDetails();
     const appStateSub = AppState.addEventListener('change', _handleAppStateChange);
@@ -95,7 +105,7 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
 
   const _handleAppStateChange = (nextAppState: AppStateStatus) => {
     if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
-      _fetchDetails(true);
+      fetchDetailsRef.current(true);
     }
 
     appState.current = nextAppState;
@@ -263,6 +273,7 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
         pendingActivities={pendingRequestsQuery.data || []}
         refreshing={activitiesQuery.isRefreshing}
         loading={activitiesQuery.isLoading}
+        failed={activitiesQuery.isError}
         activitiesEnabled={asset.layer !== 'chain'}
         onEndReached={_fetchDetails}
         onRefresh={_onRefresh}

--- a/src/utils/walletHistory.test.ts
+++ b/src/utils/walletHistory.test.ts
@@ -1,0 +1,156 @@
+import { utils as hiveTxUtils } from '@ecency/sdk/hive';
+import {
+  HIVE_LAYER_HISTORY_OPS,
+  getHistoryOpsForSymbol,
+  getNextHistoryPageParam,
+  matchesAssetTicker,
+} from './walletHistory';
+import { groomingTransactionData, transferTypes } from './wallet';
+
+const hivePerMVests = 500;
+
+describe('getHistoryOpsForSymbol', () => {
+  it('returns a distinct set per Hive-layer token', () => {
+    expect(getHistoryOpsForSymbol('HIVE')).toBe(HIVE_LAYER_HISTORY_OPS.HIVE);
+    expect(getHistoryOpsForSymbol('HBD')).toBe(HIVE_LAYER_HISTORY_OPS.HBD);
+    expect(getHistoryOpsForSymbol('HP')).toBe(HIVE_LAYER_HISTORY_OPS.HP);
+  });
+
+  it('falls back to the HIVE set for an unknown symbol', () => {
+    expect(getHistoryOpsForSymbol('WHATEVER')).toBe(HIVE_LAYER_HISTORY_OPS.HIVE);
+  });
+
+  // The bug this whole module exists for: requesting every operation made a witness
+  // account's page ~92% producer_reward, which transferTypes drops, so HIVE and HBD
+  // rendered nothing at all.
+  it('never requests operations the history cannot render', () => {
+    Object.values(HIVE_LAYER_HISTORY_OPS).forEach((ops) => {
+      expect(ops).not.toContain('producer_reward');
+      ops.forEach((op) => {
+        expect(transferTypes).toContain(op);
+      });
+    });
+  });
+
+  it('requests only operation names the chain actually defines', () => {
+    Object.values(HIVE_LAYER_HISTORY_OPS).forEach((ops) => {
+      ops.forEach((op) => {
+        expect(typeof (hiveTxUtils.operations as Record<string, number>)[op]).toBe('number');
+      });
+    });
+  });
+
+  it('requests no operation twice', () => {
+    Object.values(HIVE_LAYER_HISTORY_OPS).forEach((ops) => {
+      expect(new Set(ops).size).toBe(ops.length);
+    });
+  });
+});
+
+describe('getNextHistoryPageParam', () => {
+  // condenser_api.get_account_history returns a page in ASCENDING num order, so index 0
+  // is the older edge. Reading the last element instead advances one op per page.
+  const ascendingPage = [{ num: 8842005 }, { num: 8842006 }, { num: 8842054 }];
+
+  it('walks backwards from the oldest row on the page', () => {
+    expect(getNextHistoryPageParam(ascendingPage)).toBe(8842004);
+  });
+
+  it('stops at the start of history instead of returning the -1 newest sentinel', () => {
+    expect(getNextHistoryPageParam([{ num: 0 }, { num: 1 }])).toBeUndefined();
+  });
+
+  it('stops on an empty or missing page', () => {
+    expect(getNextHistoryPageParam([])).toBeUndefined();
+    expect(getNextHistoryPageParam(undefined)).toBeUndefined();
+  });
+
+  it('stops rather than looping when num is unusable', () => {
+    expect(getNextHistoryPageParam([{ num: 'not-a-number' }])).toBeUndefined();
+  });
+});
+
+describe('matchesAssetTicker', () => {
+  it('matches a groomed transfer to its own tab only', () => {
+    const activity = { trxIndex: 1, iconType: 'MaterialIcons', value: '10.000 HBD' };
+    expect(matchesAssetTicker(activity, 'HBD')).toBe(true);
+    expect(matchesAssetTicker(activity, 'HIVE')).toBe(false);
+  });
+
+  it('accepts VESTS on the HP tab', () => {
+    // delegate_vesting_shares keeps its on-chain VESTS denomination after grooming.
+    const activity = { trxIndex: 2, iconType: 'MaterialIcons', value: '1000.000000 VESTS' };
+    expect(matchesAssetTicker(activity, 'HP')).toBe(true);
+    expect(matchesAssetTicker(activity, 'HIVE')).toBe(false);
+  });
+
+  it('rejects an activity with no value', () => {
+    expect(matchesAssetTicker(null, 'HIVE')).toBe(false);
+    expect(matchesAssetTicker({ trxIndex: 3, iconType: 'MaterialIcons' }, 'HIVE')).toBe(false);
+  });
+});
+
+describe('wallet history pipeline', () => {
+  // Shape of a real condenser_api.get_account_history page after the SDK normalises it.
+  const witnessPage = [
+    { num: 10, type: 'producer_reward', timestamp: '2026-08-11T06:00:00', vesting_shares: '5.0' },
+    {
+      num: 11,
+      type: 'curation_reward',
+      timestamp: '2026-08-11T06:01:00',
+      reward: '1000.000000 VESTS',
+      comment_author: 'alice',
+      comment_permlink: 'p',
+    },
+    {
+      num: 12,
+      type: 'transfer',
+      timestamp: '2026-08-11T06:02:00',
+      amount: '3.000 HIVE',
+      from: 'alice',
+      to: 'bob',
+      memo: '',
+    },
+    {
+      num: 13,
+      type: 'transfer',
+      timestamp: '2026-08-11T06:03:00',
+      amount: '7.000 HBD',
+      from: 'bob',
+      to: 'alice',
+      memo: '',
+    },
+    {
+      num: 14,
+      type: 'delegate_vesting_shares',
+      timestamp: '2026-08-11T06:04:00',
+      delegator: 'alice',
+      delegatee: 'bob',
+      vesting_shares: '1000.000000 VESTS',
+    },
+  ];
+
+  const render = (symbol: string) =>
+    witnessPage
+      .filter((tx) => transferTypes.includes(tx.type))
+      .map((tx) => groomingTransactionData(tx, hivePerMVests))
+      .filter((activity) => matchesAssetTicker(activity, symbol));
+
+  it('renders rows on the HIVE and HBD tabs', () => {
+    expect(render('HIVE')).toHaveLength(1);
+    expect(render('HBD')).toHaveLength(1);
+  });
+
+  it('keeps VESTS-denominated rows on the HP tab', () => {
+    const hp = render('HP');
+    expect(hp.map((activity) => activity!.textKey)).toEqual(
+      expect.arrayContaining(['curation_reward', 'delegate_vesting_shares']),
+    );
+  });
+
+  it('drops producer_reward everywhere', () => {
+    ['HIVE', 'HBD', 'HP'].forEach((symbol) => {
+      expect(render(symbol).map((activity) => activity!.textKey)).not.toContain('producer_reward');
+    });
+  });
+});

--- a/src/utils/walletHistory.test.ts
+++ b/src/utils/walletHistory.test.ts
@@ -44,6 +44,20 @@ describe('getHistoryOpsForSymbol', () => {
       expect(new Set(ops).size).toBe(ops.length);
     });
   });
+
+  // Requestable only since @ecency/sdk 2.3.80; before that the per-asset select
+  // discarded it however it was asked for.
+  it('asks for savings-withdrawal completions on the liquid tabs', () => {
+    expect(HIVE_LAYER_HISTORY_OPS.HIVE).toContain('fill_transfer_from_savings');
+    expect(HIVE_LAYER_HISTORY_OPS.HBD).toContain('fill_transfer_from_savings');
+  });
+
+  // A power-down installment pays HIVE, so it has to be requested on the HIVE tab and
+  // not only on HP.
+  it('asks for power-down payouts on both HIVE and HP', () => {
+    expect(HIVE_LAYER_HISTORY_OPS.HIVE).toContain('fill_vesting_withdraw');
+    expect(HIVE_LAYER_HISTORY_OPS.HP).toContain('fill_vesting_withdraw');
+  });
 });
 
 describe('matchesAssetTicker', () => {
@@ -63,6 +77,36 @@ describe('matchesAssetTicker', () => {
   it('rejects an activity with no value', () => {
     expect(matchesAssetTicker(null, 'HIVE')).toBe(false);
     expect(matchesAssetTicker({ trxIndex: 3, iconType: 'MaterialIcons' }, 'HIVE')).toBe(false);
+  });
+
+  // A power-up is an HP event even though grooming keeps the HIVE amount that went in,
+  // so the ticker alone would drop it from the HP tab.
+  it('keeps a power-up on the HP tab and on HIVE', () => {
+    const powerUp = {
+      trxIndex: 4,
+      iconType: 'MaterialIcons',
+      textKey: 'transfer_to_vesting',
+      value: '10.000 HIVE',
+    };
+    expect(matchesAssetTicker(powerUp, 'HP')).toBe(true);
+    expect(matchesAssetTicker(powerUp, 'HIVE')).toBe(true);
+    expect(matchesAssetTicker(powerUp, 'HBD')).toBe(false);
+  });
+
+  // A power-down installment pays HIVE; the routed-to-vesting variant pays VESTS.
+  it('routes each power-down payout to the tab matching its denomination', () => {
+    const liquid = {
+      trxIndex: 5,
+      iconType: 'MaterialIcons',
+      textKey: 'fill_vesting_withdraw',
+      value: '5.000 HIVE',
+    };
+    const routed = { ...liquid, trxIndex: 6, value: '1000.000000 VESTS' };
+
+    expect(matchesAssetTicker(liquid, 'HIVE')).toBe(true);
+    expect(matchesAssetTicker(liquid, 'HP')).toBe(false);
+    expect(matchesAssetTicker(routed, 'HP')).toBe(true);
+    expect(matchesAssetTicker(routed, 'HIVE')).toBe(false);
   });
 });
 

--- a/src/utils/walletHistory.test.ts
+++ b/src/utils/walletHistory.test.ts
@@ -2,7 +2,6 @@ import { utils as hiveTxUtils } from '@ecency/sdk/hive';
 import {
   HIVE_LAYER_HISTORY_OPS,
   getHistoryOpsForSymbol,
-  getNextHistoryPageParam,
   matchesAssetTicker,
 } from './walletHistory';
 import { groomingTransactionData, transferTypes } from './wallet';
@@ -44,29 +43,6 @@ describe('getHistoryOpsForSymbol', () => {
     Object.values(HIVE_LAYER_HISTORY_OPS).forEach((ops) => {
       expect(new Set(ops).size).toBe(ops.length);
     });
-  });
-});
-
-describe('getNextHistoryPageParam', () => {
-  // condenser_api.get_account_history returns a page in ASCENDING num order, so index 0
-  // is the older edge. Reading the last element instead advances one op per page.
-  const ascendingPage = [{ num: 8842005 }, { num: 8842006 }, { num: 8842054 }];
-
-  it('walks backwards from the oldest row on the page', () => {
-    expect(getNextHistoryPageParam(ascendingPage)).toBe(8842004);
-  });
-
-  it('stops at the start of history instead of returning the -1 newest sentinel', () => {
-    expect(getNextHistoryPageParam([{ num: 0 }, { num: 1 }])).toBeUndefined();
-  });
-
-  it('stops on an empty or missing page', () => {
-    expect(getNextHistoryPageParam([])).toBeUndefined();
-    expect(getNextHistoryPageParam(undefined)).toBeUndefined();
-  });
-
-  it('stops rather than looping when num is unusable', () => {
-    expect(getNextHistoryPageParam([{ num: 'not-a-number' }])).toBeUndefined();
   });
 });
 

--- a/src/utils/walletHistory.ts
+++ b/src/utils/walletHistory.ts
@@ -1,0 +1,88 @@
+import type { HiveOperationFilterValue } from '@ecency/sdk';
+import { CoinActivity } from '../redux/reducers/walletReducer';
+
+/**
+ * Pure helpers backing the Hive-layer wallet history (`useActivitiesQuery`).
+ *
+ * They live outside `walletQueries.ts` so they can be unit tested without pulling in
+ * React, redux and the whole SDK query surface.
+ */
+
+/**
+ * Operations requested per token, resolved by the SDK into a server-side bitmask.
+ *
+ * Each list is exactly the set that survives all three downstream filters -- the SDK's
+ * per-asset `select`, `transferTypes` in `./wallet`, and `matchesAssetTicker` below --
+ * so no operation is fetched only to be discarded on device. That matters: asking for
+ * every operation (the previous behaviour) means a witness account's newest page of 50
+ * is ~92% `producer_reward`, which `transferTypes` drops, leaving the HIVE and HBD
+ * history empty on an HTTP 200.
+ *
+ * Deliberately absent: `escrow_*` and `cancel_transfer_from_savings` (groomed to an id
+ * / "0", so they can never match a ticker) and `fill_transfer_from_savings` (the SDK's
+ * HIVE and HBD `select` drops it regardless of what we request).
+ */
+const BASE_HISTORY_OPS: HiveOperationFilterValue[] = [
+  'transfer',
+  'transfer_to_savings',
+  'transfer_from_savings',
+  'recurrent_transfer',
+  'fill_recurrent_transfer',
+  'claim_reward_balance',
+  'author_reward',
+  'comment_benefactor_reward',
+];
+
+export const HIVE_LAYER_HISTORY_OPS: Record<string, HiveOperationFilterValue[]> = {
+  HIVE: [...BASE_HISTORY_OPS, 'transfer_to_vesting', 'fill_order', 'fill_convert_request'],
+  HBD: [...BASE_HISTORY_OPS, 'fill_order', 'fill_convert_request'],
+  HP: [
+    'claim_reward_balance',
+    'author_reward',
+    'comment_benefactor_reward',
+    'curation_reward',
+    'transfer_to_vesting',
+    'withdraw_vesting',
+    'fill_vesting_withdraw',
+    'delegate_vesting_shares',
+  ],
+};
+
+export const getHistoryOpsForSymbol = (symbol: string): HiveOperationFilterValue[] =>
+  HIVE_LAYER_HISTORY_OPS[symbol] ?? HIVE_LAYER_HISTORY_OPS.HIVE;
+
+/**
+ * Cursor for `condenser_api.get_account_history`.
+ *
+ * A page comes back in ASCENDING `num` order, so the OLDEST entry sits at index 0 and
+ * paging backwards means `page[0].num - 1`. The SDK's own cursor reads the LAST element
+ * (the newest), which walks the window back by a single operation per page -- 49 of 50
+ * rows duplicated -- and, once `num` reaches 0, yields -1: the "newest" sentinel, which
+ * restarts the walk at the head of the history and never terminates.
+ */
+export const getNextHistoryPageParam = (
+  lastPage: { num?: number | string }[] | undefined,
+): number | undefined => {
+  if (!lastPage?.length) {
+    return undefined;
+  }
+
+  const oldest = Number(lastPage[0]?.num ?? 0);
+  return Number.isFinite(oldest) && oldest > 0 ? oldest - 1 : undefined;
+};
+
+/**
+ * Does a groomed activity belong on the tab for `symbol`?
+ *
+ * `delegate_vesting_shares` and `fill_vesting_withdraw` keep their on-chain VESTS
+ * denomination through grooming, so the HP tab has to accept both tickers or those rows
+ * are silently dropped.
+ */
+export const matchesAssetTicker = (activity: CoinActivity | null, symbol: string): boolean => {
+  if (!activity?.value) {
+    return false;
+  }
+
+  const tickers = symbol === 'HP' ? ['HP', 'VESTS'] : [symbol];
+  return tickers.some((ticker) => activity.value!.includes(ticker));
+};

--- a/src/utils/walletHistory.ts
+++ b/src/utils/walletHistory.ts
@@ -18,14 +18,17 @@ import { CoinActivity } from '../redux/reducers/walletReducer';
  * is ~92% `producer_reward`, which `transferTypes` drops, leaving the HIVE and HBD
  * history empty on an HTTP 200.
  *
- * Deliberately absent: `escrow_*` and `cancel_transfer_from_savings` (groomed to an id
- * / "0", so they can never match a ticker) and `fill_transfer_from_savings` (the SDK's
- * HIVE and HBD `select` drops it regardless of what we request).
+ * Deliberately absent: `escrow_*` and `cancel_transfer_from_savings`, groomed to an id
+ * / "0", so they can never match a ticker.
  */
 const BASE_HISTORY_OPS: HiveOperationFilterValue[] = [
   'transfer',
   'transfer_to_savings',
   'transfer_from_savings',
+  // The virtual op that lands when a savings withdrawal's timer completes. Requestable
+  // since @ecency/sdk 2.3.80: before that the HIVE and HBD `select` discarded it however
+  // it was asked for, and the operation was missing from the SDK's transfers group.
+  'fill_transfer_from_savings',
   'recurrent_transfer',
   'fill_recurrent_transfer',
   'claim_reward_balance',
@@ -50,26 +53,6 @@ export const HIVE_LAYER_HISTORY_OPS: Record<string, HiveOperationFilterValue[]> 
 
 export const getHistoryOpsForSymbol = (symbol: string): HiveOperationFilterValue[] =>
   HIVE_LAYER_HISTORY_OPS[symbol] ?? HIVE_LAYER_HISTORY_OPS.HIVE;
-
-/**
- * Cursor for `condenser_api.get_account_history`.
- *
- * A page comes back in ASCENDING `num` order, so the OLDEST entry sits at index 0 and
- * paging backwards means `page[0].num - 1`. The SDK's own cursor reads the LAST element
- * (the newest), which walks the window back by a single operation per page -- 49 of 50
- * rows duplicated -- and, once `num` reaches 0, yields -1: the "newest" sentinel, which
- * restarts the walk at the head of the history and never terminates.
- */
-export const getNextHistoryPageParam = (
-  lastPage: { num?: number | string }[] | undefined,
-): number | undefined => {
-  if (!lastPage?.length) {
-    return undefined;
-  }
-
-  const oldest = Number(lastPage[0]?.num ?? 0);
-  return Number.isFinite(oldest) && oldest > 0 ? oldest - 1 : undefined;
-};
 
 /**
  * Does a groomed activity belong on the tab for `symbol`?

--- a/src/utils/walletHistory.ts
+++ b/src/utils/walletHistory.ts
@@ -37,7 +37,16 @@ const BASE_HISTORY_OPS: HiveOperationFilterValue[] = [
 ];
 
 export const HIVE_LAYER_HISTORY_OPS: Record<string, HiveOperationFilterValue[]> = {
-  HIVE: [...BASE_HISTORY_OPS, 'transfer_to_vesting', 'fill_order', 'fill_convert_request'],
+  HIVE: [
+    ...BASE_HISTORY_OPS,
+    'transfer_to_vesting',
+    // A power-down installment pays out in HIVE, so it belongs on this tab too. The
+    // routed-to-vesting variant denominates `deposited` in VESTS and is filtered out
+    // here by the ticker match, landing on HP instead.
+    'fill_vesting_withdraw',
+    'fill_order',
+    'fill_convert_request',
+  ],
   HBD: [...BASE_HISTORY_OPS, 'fill_order', 'fill_convert_request'],
   HP: [
     'claim_reward_balance',
@@ -55,15 +64,28 @@ export const getHistoryOpsForSymbol = (symbol: string): HiveOperationFilterValue
   HIVE_LAYER_HISTORY_OPS[symbol] ?? HIVE_LAYER_HISTORY_OPS.HIVE;
 
 /**
+ * Operations that belong to a tab structurally rather than by denomination. A power-up
+ * is an HP event, but its groomed value is the HIVE amount that went in, so a ticker
+ * match alone would drop it from the HP tab.
+ */
+const STRUCTURAL_OPS: Record<string, string[]> = {
+  HP: ['transfer_to_vesting'],
+};
+
+/**
  * Does a groomed activity belong on the tab for `symbol`?
  *
- * `delegate_vesting_shares` and `fill_vesting_withdraw` keep their on-chain VESTS
- * denomination through grooming, so the HP tab has to accept both tickers or those rows
- * are silently dropped.
+ * `delegate_vesting_shares` and the routed variant of `fill_vesting_withdraw` keep their
+ * on-chain VESTS denomination through grooming, so the HP tab has to accept both tickers
+ * or those rows are silently dropped.
  */
 export const matchesAssetTicker = (activity: CoinActivity | null, symbol: string): boolean => {
   if (!activity?.value) {
     return false;
+  }
+
+  if (STRUCTURAL_OPS[symbol]?.includes(activity.textKey ?? '')) {
+    return true;
   }
 
   const tickers = symbol === 'HP' ? ['HP', 'VESTS'] : [symbol];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.79":
-  version "2.3.79"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.79.tgz#fd31c179eef7d1478cd2296f4a17f715400ade7e"
-  integrity sha512-zpsj4+uAbXM9g7FLHCBvszDjnQtCaH/TcqgkFhtcsP6EDLu+MEaKWF26fs6Tfz3WXhbt4rUv0o5tltEAdR0Gpg==
+"@ecency/sdk@^2.3.80":
+  version "2.3.80"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.80.tgz#e285dd3f9523ed5d7ff2d663c2270c36a0e209c5"
+  integrity sha512-5rYRxXt+iKAHX6CPi3m2KZACGyszKzsMthv1kjZa/yy8K1EtzyMCYk0t+mIxRH+XTZ9LIOCgKj3Q/sFA8gTfkQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Opening the HIVE or HBD token screen showed no transaction history.

## Cause

`useActivitiesQuery` called `getTransactionsInfiniteQueryOptions(username, 50)` with no operation group, so the SDK fell back to `ALL_ACCOUNT_OPERATIONS` (30 op-type ids, including `producer_reward` and `curation_reward`) against hafah's REST `/accounts/{name}/operations`. That produced the symptom two ways:

**Empty list on an HTTP 200.** Measured on `good-karma`: the 30-id filter matches 5.86M operations, ~81% of them `producer_reward`. The newest page of 50 came back as 46 `producer_reward` + 4 `curation_reward`. `producer_reward` is not in `transferTypes`, and `curation_reward` grooms to `"n HP"`, so HIVE and HBD rendered zero rows. Because the page added nothing, the list's content length never changed, `onEndReached` never re-fired, and the walk stalled ~62 pages short of the first transfer. HP still worked, which is why the report named HIVE and HBD only.

**Query failure.** The same wide predicate is expensive server-side. Cold, per node, for that exact request:

| node | good-karma (5.86M ops) |
|---|---|
| api.hive.blog | HTTP 500 `57014 canceling statement due to statement timeout` @ 15.3s |
| rpc.mahdiyari.info | 15.3s |
| api.syncad.com | 7.4s |
| hiveapi.actifit.io | HTTP 500 @ 15.1s |
| api.c0ff33a.uk | 0.7s |

`sdk-config.ts` sets a 10s client ceiling, and the REST pool is the SDK default order, so the walk starts on the two slowest hosts and gives up before reaching the fastest. Nothing surfaced the error, so a failed load looked identical to an empty one.

## Change

Moves the Hive layer onto the per-asset SDK queries the web wallet already uses (`condenser_api.get_account_history` with a server-side operation bitmask) and requests only the operations each tab can actually render. Same account, same data: 0.2-1.5s instead of 2-28s, and every returned row is renderable (`good-karma` HIVE page 1 goes from 0 usable rows to 50).

Two SDK behaviours are overridden locally, both load-bearing:

- `initialData: { pages: [], pageParams: [] }` exists for the web's prefetched pages. Against mobile's `staleTime: 60_000` that empty seed reads as fresh data and suppresses the first fetch entirely.
- `getNextPageParam` reads `lastPage[lastPage.length - 1].num`, but `get_account_history` returns a page in **ascending** `num` order, so that is the *newest* row. Verified live: page 1 and page 2 overlapped by 49 of 50 rows. At the end of history it yields `-1`, the "newest" sentinel, restarting the walk forever.

Also fixed along the way:

- `useActivitiesQuery` now returns `isError`/`error`, and the list renders a real empty/failed state instead of a bare header.
- Bounded auto-advance (max 5 pages) for when a page is legitimately filtered down to zero rows.
- The HP tab accepts `VESTS`, so `delegate_vesting_shares` and `fill_vesting_withdraw` stop being dropped by the ticker match.
- `useRecurringActivitesQuery` runs again: every caller passes the symbol (`'HIVE'`) but it gated on `ASSET_IDS.HIVE` (`'hive'`), so it was permanently disabled and the coin summary was stuck on zero recurrent transfers.
- Stable list keys, explicit section keys, `onEndReachedThreshold`, and a ref-backed AppState handler that no longer restarts an in-flight refetch.

## Tests

New `src/utils/walletHistory.test.ts` (15 tests) covers the cursor direction and its termination at `num === 0`, the ticker match including VESTS on HP, a contract test asserting every requested operation name exists on-chain and is renderable by `transferTypes` + `groomingTransactionData`, and a witness-account fixture page asserting HIVE and HBD each yield rows and `producer_reward` never does.

`yarn typecheck` clean, `yarn test:ci` 753 passed / 1 skipped.

## Follow-ups for @ecency/sdk

Not on the critical path, needs a separate release:

- `getNextPageParam` in `get-hive-asset-transactions-query-options.ts` is wrong for web too (it currently re-fetches 49 duplicate rows per page).
- `ALL_ACCOUNT_OPERATIONS` lists `fill_recurrent_transfer` twice and omits `fill_transfer_from_savings`.
- The group-less default should drop `producer_reward`, or `group` should be required.
- The per-asset `select` hard-drops `fill_transfer_from_savings` and `escrow_*` on HIVE/HBD even when explicitly requested, so those rows can't be shown from the client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved wallet activity history for HIVE, HBD, and Hive Power.
  * Added automatic pagination to find matching wallet activity.
  * Added clearer empty-state and retry guidance when transaction history cannot be loaded.

* **Bug Fixes**
  * Improved activity filtering and support for legacy asset formats.
  * Ensured wallet activity refreshes correctly when returning to the app.
  * Removed unsupported producer reward entries from wallet history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->