### PR TITLE
hivesigner: carry the broadcast result back from the signing WebView

### DIFF
--- a/src/components/hiveSignerModal/hiveSignerModal.tsx
+++ b/src/components/hiveSignerModal/hiveSignerModal.tsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import WebView from 'react-native-webview';
 import { Platform, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import type { Operation } from '@ecency/sdk';
+import type { Operation, TransactionConfirmation } from '@ecency/sdk';
 import { hsOptions } from '../../constants/hsOptions';
 import styles from './hiveSignerModal.styles';
 import { ModalHeader } from '../modalHeader';
@@ -12,6 +12,7 @@ import { StatusContent } from '../hiveAuthModal/children/statusContent';
 import AUTH_TYPE from '../../constants/authType';
 import { useAppSelector } from '../../hooks';
 import { selectCurrentAccount } from '../../redux/selectors';
+import { parseHiveSignerSignResult } from '../../utils/hiveSignerCallback';
 
 export const HiveSignerModal = ({ route, navigation }: any) => {
   const intl = useIntl();
@@ -104,30 +105,24 @@ export const HiveSignerModal = ({ route, navigation }: any) => {
       return;
     }
 
-    // Parse URL robustly to detect success
-    let isSuccess = false;
-    try {
-      if (url.includes('/sign/success')) {
-        isSuccess = true;
-      } else {
-        const parsedUrl = new URL(url);
-        const successParam = parsedUrl.searchParams.get('success');
-        if (successParam === 'true') {
-          isSuccess = true;
-        }
-      }
-    } catch (error) {
-      // If URL parsing fails, fall back to includes check
-      if (url.includes('?success=true')) {
-        isSuccess = true;
-      }
-    }
+    const result = parseHiveSignerSignResult(url, hsOptions.redirect_uri);
 
-    if (isSuccess) {
+    if (result) {
       // Mark success as handled to prevent duplicate calls
       successHandledRef.current = true;
-      // Transaction was successfully signed
-      onSuccessRef.current?.();
+      // Transaction was successfully signed. Pass the confirmation through when the
+      // callback carried one: the SDK gates recordActivity on the transaction id, so
+      // without it the action earns nothing and never reaches quest progress.
+      onSuccessRef.current?.(
+        result.id
+          ? ({
+              id: result.id,
+              block_num: result.blockNum,
+              trx_num: result.trxNum,
+              expired: false,
+            } as unknown as TransactionConfirmation)
+          : undefined,
+      );
       navigation.goBack();
     }
   };
@@ -155,7 +150,15 @@ export const HiveSignerModal = ({ route, navigation }: any) => {
     return null;
   }
 
-  const _hsUri = `${hsOptions.base_url}${hiveuri.substring(7)}`;
+  // Ask HiveSigner to hand the broadcast result back. Without a redirect_uri (or a
+  // callback baked into the uri) it simply stops on its own success page, which is why
+  // the signing path never had a transaction id to record the point activity with. The
+  // loopback URI is the one already registered for this client and used by the OAuth
+  // login flow: the WebView never actually loads it, it only reads the query params off
+  // the navigation attempt.
+  const _hsUri = `${hsOptions.base_url}${hiveuri.substring(7)}${
+    hiveuri.includes('?') ? '&' : '?'
+  }redirect_uri=${encodeURIComponent(hsOptions.redirect_uri)}`;
 
   // Render HiveSigner WebView for HiveSigner operations
   return (

--- a/src/providers/sdk/mobilePlatformAdapter.ts
+++ b/src/providers/sdk/mobilePlatformAdapter.ts
@@ -194,7 +194,11 @@ export function createMobilePlatformAdapter(params: MobilePlatformAdapterParams)
             params: {
               hiveuri: encodedUri,
               opsArray: ops,
-              onSuccess: () => resolve({} as TransactionConfirmation),
+              // The modal hands back a real confirmation when HiveSigner's callback
+              // carried one. Resolving an empty object loses the transaction id, and
+              // the SDK gates recordActivity on it, so the action earns nothing.
+              onSuccess: (confirmation?: TransactionConfirmation) =>
+                resolve(confirmation ?? ({} as TransactionConfirmation)),
               onClose: () => reject(new Error('HiveSigner signing cancelled')),
             },
           });
@@ -221,9 +225,11 @@ export function createMobilePlatformAdapter(params: MobilePlatformAdapterParams)
           params: {
             hiveuri: encodedUri,
             opsArray: ops,
-            onSuccess: () => {
-              // HiveSigner WebView confirms via URL redirect, no tx confirmation returned
-              resolve({} as TransactionConfirmation);
+            onSuccess: (confirmation?: TransactionConfirmation) => {
+              // The modal reads the broadcast result off HiveSigner's callback. Falling
+              // back to an empty object keeps the old behaviour when no id came through,
+              // but with one the SDK can finally record the point activity.
+              resolve(confirmation ?? ({} as TransactionConfirmation));
             },
             onClose: () => {
               reject(new Error('HiveSigner signing cancelled'));

--- a/src/utils/hiveSignerCallback.test.ts
+++ b/src/utils/hiveSignerCallback.test.ts
@@ -1,0 +1,44 @@
+import { parseHiveSignerSignResult } from './hiveSignerCallback';
+
+const REDIRECT = 'http://127.0.0.1:3000/auth';
+
+describe('parseHiveSignerSignResult', () => {
+  it('reads the transaction id off the callback', () => {
+    const result = parseHiveSignerSignResult(
+      `${REDIRECT}?id=6f7c217c2f5a09a5b84fc73a33c5178d236b7059&block=108922746&txn=3&sig=abc`,
+      REDIRECT,
+    );
+
+    expect(result).toEqual({
+      id: '6f7c217c2f5a09a5b84fc73a33c5178d236b7059',
+      blockNum: 108922746,
+      trxNum: 3,
+    });
+  });
+
+  it('keeps the id when block and txn are missing', () => {
+    const result = parseHiveSignerSignResult(`${REDIRECT}?id=abc123`, REDIRECT);
+
+    expect(result).toEqual({ id: 'abc123', blockNum: undefined, trxNum: undefined });
+  });
+
+  it('treats a callback without an id as nothing happened', () => {
+    // Not a success we can act on, and reporting one would resolve the broadcast with
+    // no transaction id, which is the bug this parsing exists to close.
+    expect(parseHiveSignerSignResult(`${REDIRECT}?sig=abc`, REDIRECT)).toBeNull();
+  });
+
+  it('still recognises the legacy success shapes, without an id', () => {
+    expect(parseHiveSignerSignResult('https://hivesigner.com/sign/success', REDIRECT)).toEqual({});
+    expect(parseHiveSignerSignResult('https://hivesigner.com/x?success=true', REDIRECT)).toEqual(
+      {},
+    );
+  });
+
+  it('says nothing about an ordinary navigation', () => {
+    expect(parseHiveSignerSignResult('https://hivesigner.com/sign/op/abc', REDIRECT)).toBeNull();
+    expect(parseHiveSignerSignResult('https://hivesigner.com/login', REDIRECT)).toBeNull();
+    expect(parseHiveSignerSignResult(undefined, REDIRECT)).toBeNull();
+    expect(parseHiveSignerSignResult('', REDIRECT)).toBeNull();
+  });
+});

--- a/src/utils/hiveSignerCallback.ts
+++ b/src/utils/hiveSignerCallback.ts
@@ -1,0 +1,64 @@
+export interface HiveSignerSignResult {
+  /** The signed transaction id, when HiveSigner handed one back. */
+  id?: string;
+  blockNum?: number;
+  trxNum?: number;
+}
+
+/**
+ * Read the outcome of a HiveSigner hot-signing session off a WebView navigation.
+ *
+ * HiveSigner resolves the configured callback with `sig`, `id`, `block` and `txn`
+ * (see its sign page), so the callback navigation is where the transaction id lives.
+ * The SDK gates `recordActivity` on that id, so losing it means the action earns no
+ * points and never shows up in quest progress.
+ *
+ * Returns null when the url says nothing about the outcome. The two legacy shapes are
+ * still recognised so a session that somehow lands on them is not treated as a
+ * cancellation, they just carry no transaction id.
+ */
+export const parseHiveSignerSignResult = (
+  url: string | undefined | null,
+  redirectUri: string,
+): HiveSignerSignResult | null => {
+  if (!url) {
+    return null;
+  }
+
+  if (url.startsWith(redirectUri)) {
+    try {
+      const params = new URL(url).searchParams;
+      const id = params.get('id');
+      if (!id) {
+        return null;
+      }
+
+      const blockNum = Number(params.get('block'));
+      const trxNum = Number(params.get('txn'));
+
+      return {
+        id,
+        blockNum: Number.isFinite(blockNum) && blockNum > 0 ? blockNum : undefined,
+        trxNum: Number.isFinite(trxNum) && trxNum > 0 ? trxNum : undefined,
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  if (url.includes('/sign/success')) {
+    return {};
+  }
+
+  try {
+    if (new URL(url).searchParams.get('success') === 'true') {
+      return {};
+    }
+  } catch (error) {
+    if (url.includes('?success=true')) {
+      return {};
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
Closes #3472.

⚠️ **Needs a device pass with a HiveSigner account before merge.** See "What I could not verify" below.

## The bug

Anything signed through the HiveSigner WebView earned nothing. The adapter resolved both WebView paths with `{} as TransactionConfirmation`, and the SDK mutations gate activity recording on a transaction id:

```ts
const txId = result?.id ?? result?.tx_id;
if (auth?.adapter?.recordActivity && txId) { ... }
```

So `recordActivity` was skipped silently. The broadcast itself succeeded, so the user watched their vote or comment land on chain and reasonably expected it to count.

## Why there was no id to pass

Nothing asked HiveSigner for one. Reading its sign page source, it only redirects when the request carries a `redirect_uri` query param or a `callback` baked into the hive-uri:

```ts
if (confirmation && (this.$route.query.redirect_uri || this.parsed.params.callback)) {
  const cburl = this.parsed.params.callback || `${this.$route.query.redirect_uri}?id=${confirmation.id}`
  window.location = hiveuri.resolveCallback(cburl, {
    sig, id: confirmation.id || undefined,
    block: confirmation.block_num || undefined,
    txn: confirmation.trx_num || undefined
  })
}
```

The modal built its URL as `base_url + hiveuri.substring(7)`, with neither, so HiveSigner just stopped on its own success page.

The request now includes the loopback `redirect_uri` already registered for this client and used by the OAuth login flow. As there, the WebView never actually loads that URL, it only reads the query params off the navigation attempt.

## Shape of the change

Parsing moved into a pure `parseHiveSignerSignResult` helper, so the callback contract is pinned by tests rather than buried in a WebView handler. The adapter now resolves whatever confirmation the modal produces, falling back to the old empty object when there is none.

Both previous success shapes (`/sign/success` and `?success=true`) are still recognised, so a session that somehow reaches them is treated as success exactly as before, just without an id. That is what keeps this additive rather than a rewrite of the success detection.

## Verification

```
yarn test:ci    51 passed, 1 skipped (52 suites), 747 passed, 1 skipped (748 tests)
yarn typecheck  0 errors (baseline 0)
yarn lint       0 errors
```

New tests cover the callback contract: the id, block and txn are read off the callback; a callback without an id is treated as nothing happened (reporting success there would resolve the broadcast with no id, which is the bug this exists to close); the legacy shapes still resolve as success without an id; ordinary navigations say nothing.

## What I could not verify

Everything above about HiveSigner's behaviour comes from reading its source, not from a signing session. Specifically unconfirmed:

1. That `ecency.app`'s registered redirect URIs accept the loopback URI for the **sign** flow. It is accepted for OAuth login, which is good evidence, not proof.
2. That the deployed hivesigner.com matches the source I read.
3. Whether the previous `/sign/success` detection ever fired. I could find no code path in HiveSigner that produces either legacy shape, which would mean this WebView path never resolved at all and the promise hung until the user closed the modal. If that is right, this PR also fixes a hang. I have left both shapes in rather than act on that reading.

A device pass should confirm: signing through the WebView closes the modal on success, the action appears in points history, and quest progress moves within a couple of minutes.
