### PR TITLE
fix(wallet): never use RPC nodes that serve accounts without metadata

### DIFF
--- a/src/constants/options/api.test.ts
+++ b/src/constants/options/api.test.ts
@@ -1,0 +1,35 @@
+import { BLOCKED_SERVERS, SERVER_LIST, isBlockedServer, withoutBlockedServers } from './api';
+
+describe('blocked servers', () => {
+  it('does not ship a denied node in the fallback list', () => {
+    expect(withoutBlockedServers([...SERVER_LIST])).toEqual([...SERVER_LIST]);
+  });
+
+  it('flags denied nodes', () => {
+    BLOCKED_SERVERS.forEach((server) => {
+      expect(isBlockedServer(server)).toBe(true);
+    });
+  });
+
+  it('ignores case and a trailing slash', () => {
+    expect(isBlockedServer('https://TechCoderX.com/')).toBe(true);
+    expect(isBlockedServer('  https://techcoderx.com  ')).toBe(true);
+  });
+
+  it('allows nodes that are not denied', () => {
+    expect(isBlockedServer('https://api.hive.blog')).toBe(false);
+    expect(isBlockedServer(undefined)).toBe(false);
+    expect(isBlockedServer(null)).toBe(false);
+  });
+
+  it('drops denied nodes from a pool while preserving order', () => {
+    expect(
+      withoutBlockedServers([
+        'https://api.hive.blog',
+        'https://techcoderx.com',
+        'https://api.deathwing.me',
+        'https://hiveapi.actifit.io',
+      ]),
+    ).toEqual(['https://api.hive.blog', 'https://api.deathwing.me']);
+  });
+});

--- a/src/constants/options/api.ts
+++ b/src/constants/options/api.ts
@@ -12,9 +12,42 @@ export const VALUE = API_OPTIONS;
 export const SERVER_LIST = [
   'https://api.deathwing.me',
   'https://rpc.mahdiyari.info',
-  'https://techcoderx.com',
   'https://api.openhive.network',
   'https://api.c0ff33a.uk',
   'https://api.hive.blog',
   'https://api.syncad.com',
 ] as const;
+
+/**
+ * Nodes that must never serve this app, whatever the remote node list or the
+ * user's stored preference says.
+ *
+ * These answer `condenser_api.get_accounts` with `posting_json_metadata`
+ * stripped to "" while balances and reputation are correct. That is a
+ * well-formed result, so it passes shape validation and the health tracker
+ * ranks it on latency alone. Wallet token visibility is read entirely from
+ * `profile.tokens[].meta.show` in that metadata, so a stripped row reads as
+ * "this user enabled nothing" and the wallet silently drops the user's
+ * Hive-Engine and chain tokens back to HIVE/HP/HBD/Points.
+ *
+ * A denylist rather than just an omission: the saved-server preference is
+ * prepended to the pool when it is not already in the fetched list, so simply
+ * removing an entry would promote a stored bad node to *first* instead of
+ * dropping it.
+ */
+export const BLOCKED_SERVERS: readonly string[] = [
+  'https://techcoderx.com',
+  'https://hiveapi.actifit.io',
+];
+
+const normalizeServer = (server: string) => server.trim().replace(/\/+$/, '').toLowerCase();
+
+const BLOCKED_SERVER_SET = new Set(BLOCKED_SERVERS.map(normalizeServer));
+
+/** True when a server must not be used (see BLOCKED_SERVERS). */
+export const isBlockedServer = (server?: string | null): boolean =>
+  typeof server === 'string' && BLOCKED_SERVER_SET.has(normalizeServer(server));
+
+/** Drops any denied nodes from a pool, preserving order. */
+export const withoutBlockedServers = (servers: readonly string[]): string[] =>
+  servers.filter((server) => !isBlockedServer(server));

--- a/src/providers/ecency/ecency.ts
+++ b/src/providers/ecency/ecency.ts
@@ -2,7 +2,7 @@ import { isArray } from 'lodash';
 import * as Sentry from '@sentry/react-native';
 import ecencyApi from '../../config/ecencyApi';
 import { upload } from '../../config/imageApi';
-import { SERVER_LIST } from '../../constants/options/api';
+import { SERVER_LIST, withoutBlockedServers } from '../../constants/options/api';
 import { convertProposalMeta } from './converters';
 import { PurchaseRequestData } from './ecency.types';
 
@@ -148,7 +148,12 @@ export const getNodes = async () => {
       throw new Error('Invalid data returned, fallback to local copy');
     }
 
-    return nodes;
+    // Screened here rather than at each call site: this is the single source of
+    // the node pool for both the SDK config and the settings picker, so a denied
+    // node cannot come back via the remote list (see BLOCKED_SERVERS).
+    const allowed = withoutBlockedServers(nodes);
+
+    return allowed.length > 0 ? allowed : [...SERVER_LIST];
   } catch (error) {
     console.warn('failed to get nodes list', error);
     Sentry.captureException(error);

--- a/src/providers/hive/hive.ts
+++ b/src/providers/hive/hive.ts
@@ -33,7 +33,7 @@ import { resolveTxRequiredAuthority } from '../../utils/hiveOperationAuthority';
 
 // Constant
 import AUTH_TYPE from '../../constants/authType';
-import { SERVER_LIST } from '../../constants/options/api';
+import { SERVER_LIST, isBlockedServer, withoutBlockedServers } from '../../constants/options/api';
 import { SIGN_IMAGE_UNAVAILABLE } from '../../constants/imageUpload';
 import { b64uEnc } from '../../utils/b64';
 import { delay } from '../../utils/editor';
@@ -42,10 +42,13 @@ import { delay } from '../../utils/editor';
 global.Buffer = global.Buffer || require('buffer').Buffer;
 
 export const checkClient = async () => {
-  const selectedServer = [...SERVER_LIST];
+  const selectedServer = withoutBlockedServers([...SERVER_LIST]);
 
   await getServer().then((response) => {
-    if (response) {
+    // A stored preference is prepended, so it has to be screened too —
+    // otherwise a denied node the user once selected becomes the first node
+    // tried (see BLOCKED_SERVERS).
+    if (response && !isBlockedServer(response)) {
       selectedServer.unshift(response);
     }
   });

--- a/src/providers/queries/sdk-config.ts
+++ b/src/providers/queries/sdk-config.ts
@@ -3,6 +3,7 @@ import Config from 'react-native-config';
 import { QueryClient } from '@tanstack/react-query';
 import { getServer } from '../../storage/storage';
 import { getNodes } from '../ecency/ecency';
+import { isBlockedServer, withoutBlockedServers } from '../../constants/options/api';
 
 /**
  * Fetch DMCA filtering lists from Ecency server
@@ -47,8 +48,12 @@ export const initSdkConfig = async (queryClient: QueryClient) => {
 
   // Sync saved server preference and fetched nodes to SDK
   const savedServer = await getServer();
-  const fetchedNodes = await getNodes();
-  const hasValidServer = typeof savedServer === 'string' && savedServer.trim() !== '';
+  // Denied nodes are dropped from BOTH sides. The saved preference is prepended
+  // when it is not already in the fetched list, so filtering only the fetched
+  // list would promote a stored bad node to the front of the pool.
+  const fetchedNodes = withoutBlockedServers(await getNodes());
+  const hasValidServer =
+    typeof savedServer === 'string' && savedServer.trim() !== '' && !isBlockedServer(savedServer);
   const nodes =
     hasValidServer && !fetchedNodes.includes(savedServer)
       ? [savedServer, ...fetchedNodes]


### PR DESCRIPTION
Fixes #3477.

## Problem

`techcoderx.com` and `hiveapi.actifit.io` answer `condenser_api.get_accounts` with `posting_json_metadata` stripped to `""` while balances and reputation are correct — verified consistently across accounts, against `api.deathwing.me` / `api.hive.blog` / `rpc.mahdiyari.info` / `api.openhive.network` which all return it in full.

Wallet token visibility is read entirely from `profile.tokens[].meta.show` in that metadata, so a stripped row reads as *"this user enabled nothing"* and the wallet silently drops the user's Hive-Engine and chain tokens back to HIVE/HP/HBD/Points.

## Why a denylist and not just deleting the entry

The saved-server preference is **prepended** to the pool when it is not already in the fetched list:

```ts
const nodes = hasValidServer && !fetchedNodes.includes(savedServer)
  ? [savedServer, ...fetchedNodes]
  : [...fetchedNodes];
```

So removing the node from the list alone would promote a stored bad node to **first** rather than removing it — a user who once picked it in settings would end up pinned to it. `checkClient()` has the same `unshift` shape.

## Change

`BLOCKED_SERVERS` plus `isBlockedServer` / `withoutBlockedServers` in `constants/options/api.ts` (case- and trailing-slash-insensitive), applied at the three points that can each reintroduce a denied node independently:

- `getNodes()` — the remote list, which also backs the settings picker. Falls back to the local list if filtering would empty it.
- `sdk-config.ts` — both the fetched list and the saved preference.
- `checkClient()` — the local pool and the saved preference.

`techcoderx.com` also removed from `SERVER_LIST`.

The remote `public-nodes.json` is being fixed in ecency/vision-web#1397, which reaches installed apps without a release; this PR makes the app resilient regardless of what that list says, and handles the stored preference, which the remote fix cannot.

## Tests

- `yarn typecheck` — clean.
- `eslint` on all changed files — 0 errors (3 pre-existing warnings).
- `jest`: **762 passed**, including a new `api.test.ts` covering the helpers and asserting the shipped fallback list contains no denied node.