### PR TITLE
editor: warn that a reply too short to earn points will not count

### DIFF
--- a/src/components/markdownEditor/styles/markdownEditorStyles.ts
+++ b/src/components/markdownEditor/styles/markdownEditorStyles.ts
@@ -53,6 +53,13 @@ export default EStyleSheet.create({
     paddingTop: 10,
     paddingBottom: 0,
   },
+  shortReplyHint: {
+    fontSize: 12,
+    color: '$iconColor',
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    backgroundColor: '$primaryBackgroundColor',
+  },
   accountTile: {
     height: 60,
     flexDirection: 'row',

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -1,9 +1,11 @@
 import { postBodySummary, renderPostBody } from '@ecency/render-helper';
+import { earnsQuestContentCredit, QUEST_MIN_CONTENT_LENGTH } from '@ecency/sdk';
 import { debounce, get } from 'lodash';
 import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import Animated, { BounceInRight } from 'react-native-reanimated';
 import { SheetManager } from 'react-native-actions-sheet';
+import { shouldShowShortReplyHint } from '../../../utils/shortReplyHint';
 import { Icon } from '../../icon';
 
 // Utils
@@ -94,6 +96,12 @@ const MarkdownEditorView = ({
   caretKeyRef.current = _caretKey;
 
   const [editable, setEditable] = useState(true);
+  // Whether the current body is long enough to earn points. Deliberately a boolean and
+  // not the text: this editor is uncontrolled on purpose (see _changeText), so anything
+  // that re-rendered per keystroke would bring back the Android typing race. Updated on
+  // the existing 500ms debounce, which already calls setIsEditing, and React bails out
+  // when the value has not flipped, so the hint costs no extra renders.
+  const [earnsPoints, setEarnsPoints] = useState(() => earnsQuestContentCredit(draftBody || ''));
   // const [bodyInputHeight, setBodyInputHeight] = useState(MIN_BODY_INPUT_HEIGHT);
   const [isSnippetsOpen, setIsSnippetsOpen] = useState(false);
   const [showDraftLoadButton, setShowDraftLoadButton] = useState(false);
@@ -250,6 +258,7 @@ const MarkdownEditorView = ({
     debounce(() => {
       console.log('setting is editing to', false);
       setIsEditing(false);
+      setEarnsPoints(earnsQuestContentCredit(bodyTextRef.current));
       handleBodyChange(bodyTextRef.current);
       handleFormUpdate('body', bodyTextRef.current);
     }, 500),
@@ -507,6 +516,19 @@ const MarkdownEditorView = ({
       _setTextAndSelection({ text: '', selection: { start: 0, end: 0 } });
     }
   };
+  // `earnsPoints` is the only part that changes as the user types, and it is recomputed
+  // on the same debounce that already re-renders this component. The remaining gates are
+  // render-stable, so reading the body ref here needs no re-render of its own. The ref is
+  // the authoritative body once the draft has loaded into it; falling back to `draftBody`
+  // would keep nagging about a reply the user had just cleared.
+  const _showShortReplyHint = shouldShowShortReplyHint({
+    isReply,
+    isEdit,
+    username: currentAccount?.name,
+    body: bodyTextRef.current,
+    earnsCredit: earnsPoints,
+  });
+
   const _renderEditor = () => (
     <>
       {isReply && !isEdit && <SummaryArea summary={headerText} />}
@@ -562,6 +584,11 @@ const MarkdownEditorView = ({
         scrollEnabled={true}
         defaultValue={bodyTextRef.current || draftBody || ''}
       />
+      {_showShortReplyHint && (
+        <Text style={styles.shortReplyHint}>
+          {intl.formatMessage({ id: 'editor.short_reply_hint' }, { n: QUEST_MIN_CONTENT_LENGTH })}
+        </Text>
+      )}
     </>
   );
 

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -570,7 +570,8 @@
     "scheduled_later": "Later",
     "settings_title": "Post Options",
     "support_ecency": "Support Ecency {percent}%",
-    "alert_btn_no": "No"
+    "alert_btn_no": "No",
+    "short_reply_hint": "Replies of {n} characters or fewer do not earn points (links do not count)"
   },
   "time": {
     "week": "weeks",

--- a/src/utils/shortReplyHint.test.ts
+++ b/src/utils/shortReplyHint.test.ts
@@ -1,0 +1,63 @@
+import { shouldShowShortReplyHint } from './shortReplyHint';
+
+jest.mock('@ecency/sdk', () => ({
+  // Mirrors the published rule: strip URLs, count code points, strictly greater than 25.
+  earnsQuestContentCredit: (body?: string | null) =>
+    Array.from((body ?? '').replace(/https?:\/\/\S+/g, '')).length > 25,
+}));
+
+const reply = (overrides: any = {}) => ({
+  isReply: true,
+  isEdit: false,
+  username: 'alice',
+  body: 'Thank you',
+  ...overrides,
+});
+
+describe('shouldShowShortReplyHint', () => {
+  it('warns on the short replies the backend refuses', () => {
+    expect(shouldShowShortReplyHint(reply({ body: 'Thank you' }))).toBe(true);
+    expect(shouldShowShortReplyHint(reply({ body: 'Lol 😂' }))).toBe(true);
+    expect(shouldShowShortReplyHint(reply({ body: '❤️' }))).toBe(true);
+  });
+
+  it('counts a link-only reply as too short, matching the backend rule', () => {
+    expect(
+      shouldShowShortReplyHint(reply({ body: 'https://i.example.com/a-very-long-url.gif' })),
+    ).toBe(true);
+  });
+
+  it('stays quiet once the reply is long enough to earn', () => {
+    expect(
+      shouldShowShortReplyHint(
+        reply({ body: 'Thank you, this is a genuinely useful reply with something to say' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('stays quiet on an untouched composer', () => {
+    expect(shouldShowShortReplyHint(reply({ body: '' }))).toBe(false);
+    expect(shouldShowShortReplyHint(reply({ body: '   ' }))).toBe(false);
+    expect(shouldShowShortReplyHint(reply({ body: undefined }))).toBe(false);
+  });
+
+  it('does not nag outside a fresh reply', () => {
+    // A post is not gated on this in practice, an edit never earns again, and a
+    // logged-out user has nothing to earn.
+    expect(shouldShowShortReplyHint(reply({ isReply: false }))).toBe(false);
+    expect(shouldShowShortReplyHint(reply({ isEdit: true }))).toBe(false);
+    expect(shouldShowShortReplyHint(reply({ username: undefined }))).toBe(false);
+    expect(shouldShowShortReplyHint(reply({ username: '' }))).toBe(false);
+  });
+
+  it('trusts a caller-supplied verdict over measuring the body again', () => {
+    // The editor is uncontrolled and measures on a debounce, so it passes its own
+    // answer in. A stale-but-supplied `true` must win over the body.
+    expect(shouldShowShortReplyHint(reply({ body: 'Thank you', earnsCredit: true }))).toBe(false);
+    expect(
+      shouldShowShortReplyHint(
+        reply({ body: 'a genuinely long reply that clears the minimum', earnsCredit: false }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/utils/shortReplyHint.ts
+++ b/src/utils/shortReplyHint.ts
@@ -1,0 +1,47 @@
+import { earnsQuestContentCredit } from '@ecency/sdk';
+
+export interface ShortReplyHintInput {
+  isReply?: boolean;
+  isEdit?: boolean;
+  /** Signed-in account name, if any. */
+  username?: string | null;
+  /** Current composer body. */
+  body?: string | null;
+  /**
+   * Whether `body` already earns credit, when the caller has computed it. The editor is
+   * uncontrolled on purpose and only measures the body on a debounce, so it passes its
+   * own answer in rather than have this recompute on every render. Omit it and this
+   * measures `body` directly.
+   */
+  earnsCredit?: boolean;
+}
+
+/**
+ * Whether to warn that this reply is too short to earn points or quest credit.
+ *
+ * The points backend drops a comment whose body is at or under a minimum length once
+ * URLs are stripped, so "Thank you", an emoji, or an image-only reply earns nothing and
+ * never reaches the daily comment quest. That rule is deliberate but invisible, and it
+ * is the single biggest source of "quests do not show my action" reports.
+ *
+ * Replies only, matching the website. An edit never earns either (the original already
+ * claimed the reward), a logged-out user has nothing to earn, and an untouched composer
+ * should not be nagged at.
+ */
+export const shouldShowShortReplyHint = ({
+  isReply,
+  isEdit,
+  username,
+  body,
+  earnsCredit,
+}: ShortReplyHintInput): boolean => {
+  if (!isReply || isEdit || !username) {
+    return false;
+  }
+
+  if (!body?.trim()) {
+    return false;
+  }
+
+  return !(earnsCredit ?? earnsQuestContentCredit(body));
+};


### PR DESCRIPTION
Closes #3473. Mirrors ecency/vision-web#1394, now that the SDK it needs is released and bumped here in #3478.

## The gap

The points backend drops a comment whose body is at or under a minimum length once URLs are stripped, so "Thank you", an emoji, or an image-only reply earns nothing and never reaches the daily comment quest. Deliberate anti-spam rule, entirely invisible in the app. Over 7 days it accounted for about a third of all comment activity submitted, which makes it the single biggest source of "quests do not show my action" reports.

The reply composer now says so before the user submits. It does not block submitting: short replies are fine, they just do not pay, and the user should be able to see that before they hit send rather than an hour later on Perks.

Replies only, matching the website. An edit never earns again (the original already claimed the reward), a logged-out user has nothing to earn, and an untouched composer is not worth nagging about.

## Where the rule comes from

`QUEST_MIN_CONTENT_LENGTH` and `earnsQuestContentCredit` come from the shared quest catalog in `@ecency/sdk`, so the app cannot drift from the rule the backend applies. That measurement counts code points rather than UTF-16 units, because the backend measures with Python's `len()`: measuring locally would score 13 emoji as 26 and the composer would promise points that were then refused.

## Not re-rendering per keystroke

This editor is uncontrolled on purpose, and the comment on `_changeText` is explicit that a per-keystroke re-render is the Android typing race the uncontrolled redesign removed. So:

- the only new state is a single earns-credit boolean
- it is recomputed on the existing 500ms debounce, which already calls `setIsEditing`
- React bails out when the value has not flipped, so the hint costs no extra renders

The predicate is a pure `shouldShowShortReplyHint` helper (same shape as `questChip.ts`) so it can be tested without standing up the editor. It takes the caller's already-computed verdict, which is what keeps the component from measuring the body again on every render.

The body is read from the ref rather than falling back to `draftBody`, so clearing a reply drops the hint instead of continuing to nag about text that is no longer there.

## Verification

```
yarn test:ci    54 passed, 1 skipped (55 suites), 773 passed, 1 skipped (774 tests)
yarn typecheck  0 errors (baseline 0)
yarn lint       0 errors
```

Ran against the real published `@ecency/sdk` 2.3.79 rather than the older copy in the shared install.

New tests cover the short replies the backend refuses, the link-only case, a reply long enough to earn, an untouched composer, the non-reply/edit/logged-out gates, and that a caller-supplied verdict wins over measuring the body again.

Not covered by tests: the rendering itself, which needs the full editor. Worth a quick manual look that the hint appears under a short reply, disappears as it gets longer, and never shows on a post or an edit.

## Follow-up worth considering

Waves are comments too, so the same rule silently applies to a short wave, and the wave composer says nothing. Out of scope here (the website has the same gap) but probably worth its own issue.
