### PR TITLE
Chat: render inline markdown in messages

### DIFF
--- a/src/screens/chats/utils/inlineMarkdown.test.ts
+++ b/src/screens/chats/utils/inlineMarkdown.test.ts
@@ -1,0 +1,124 @@
+import { parseInlineMarkdown } from './inlineMarkdown';
+
+/** Collapses spans back to text, to assert nothing is ever dropped. */
+const flat = (s: string) =>
+  parseInlineMarkdown(s)
+    .map((p) => p.text)
+    .join('');
+
+const styled = (s: string) =>
+  parseInlineMarkdown(s).filter((p) => p.bold || p.italic || p.strike || p.code);
+
+describe('parseInlineMarkdown — formatting', () => {
+  it('renders bold', () => {
+    expect(parseInlineMarkdown('this is **important** stuff')).toEqual([
+      { text: 'this is ' },
+      { text: 'important', bold: true },
+      { text: ' stuff' },
+    ]);
+  });
+
+  it('renders italic with both delimiters', () => {
+    expect(styled('an *emphatic* word')).toEqual([{ text: 'emphatic', italic: true }]);
+    expect(styled('an _emphatic_ word')).toEqual([{ text: 'emphatic', italic: true }]);
+  });
+
+  it('renders strikethrough', () => {
+    expect(styled('~~nope~~ yes')).toEqual([{ text: 'nope', strike: true }]);
+  });
+
+  it('renders inline code', () => {
+    expect(styled('run `yarn test` now')).toEqual([{ text: 'yarn test', code: true }]);
+  });
+
+  it('nests italic inside bold', () => {
+    expect(parseInlineMarkdown('**very *very* bold**')).toEqual([
+      { text: 'very ', bold: true },
+      { text: 'very', bold: true, italic: true },
+      { text: ' bold', bold: true },
+    ]);
+  });
+
+  it('treats code spans as literal, so markdown inside them is not parsed', () => {
+    expect(parseInlineMarkdown('`a **b** c`')).toEqual([{ text: 'a **b** c', code: true }]);
+  });
+});
+
+describe('parseInlineMarkdown — leaves ordinary text alone', () => {
+  it('does not italicise snake_case identifiers', () => {
+    expect(styled('file_name_here and snake_case_var')).toEqual([]);
+    expect(flat('file_name_here and snake_case_var')).toBe('file_name_here and snake_case_var');
+  });
+
+  it('does not mangle a URL containing underscores', () => {
+    const url = 'https://ecency.com/@user/my_great_post_here';
+    expect(styled(url)).toEqual([]);
+    expect(flat(url)).toBe(url);
+  });
+
+  it('does not italicise spaced asterisks used as multiplication', () => {
+    expect(styled('2 * 3 * 4 = 24')).toEqual([]);
+    expect(flat('2 * 3 * 4 = 24')).toBe('2 * 3 * 4 = 24');
+  });
+
+  it('still finds a valid pair after an invalid opening delimiter', () => {
+    // regression: skipping an invalid "*" must keep scanning the SAME rule, not abandon it
+    expect(styled('2 * 3 and *italic* here')).toEqual([{ text: 'italic', italic: true }]);
+    expect(flat('2 * 3 and *italic* here')).toBe('2 * 3 and italic here');
+    expect(styled('a_b and _real_ emphasis')).toEqual([{ text: 'real', italic: true }]);
+  });
+
+  it('leaves an unterminated delimiter as literal text', () => {
+    expect(styled('*hello there')).toEqual([]);
+    expect(flat('*hello there')).toBe('*hello there');
+    expect(flat('a ** b')).toBe('a ** b');
+  });
+
+  it('leaves bare delimiters alone', () => {
+    ['***', '___', '~~', '`', '*', '_'].forEach((s) => {
+      expect(flat(s)).toBe(s);
+    });
+  });
+
+  it('handles empty and plain input', () => {
+    expect(parseInlineMarkdown('')).toEqual([]);
+    expect(parseInlineMarkdown('just chatting')).toEqual([{ text: 'just chatting' }]);
+  });
+
+  it('does not treat block syntax as inline formatting', () => {
+    // lists, headings and quotes stay literal by design
+    ['- a point', '# heading', '> quoted'].forEach((s) => {
+      expect(flat(s)).toBe(s);
+      expect(styled(s)).toEqual([]);
+    });
+  });
+});
+
+describe('parseInlineMarkdown — never loses content', () => {
+  it('preserves every character except consumed delimiters', () => {
+    const samples = [
+      'hey **there** how are _you_ today',
+      'mixed **bold _and italic_** together',
+      'code `x` and **bold**',
+      'emoji 🥰 with **bold** after',
+      'a*b*c',
+      '**',
+      'trailing *',
+      'multi\nline **bold** text',
+    ];
+    samples.forEach((s) => {
+      const out = flat(s);
+      // every non-delimiter character survives, in order
+      const strip = (t: string) => t.replace(/[*_~`]/g, '');
+      expect(strip(out)).toBe(strip(s));
+    });
+  });
+
+  it('terminates on pathological delimiter soup', () => {
+    const nasty = `${'*'.repeat(200)}x${'_'.repeat(200)}`;
+    const started = Date.now();
+    const out = flat(nasty);
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(out.replace(/[*_~`]/g, '')).toBe('x');
+  });
+});

--- a/src/screens/chats/utils/inlineMarkdown.ts
+++ b/src/screens/chats/utils/inlineMarkdown.ts
@@ -1,0 +1,168 @@
+/**
+ * Inline markdown for chat messages: bold, italic, strikethrough and inline code.
+ *
+ * Deliberately a SUBSET. Block constructs (lists, headings, blockquotes) are left alone so a
+ * message that happens to start with "-" or "#" keeps reading the way the sender typed it, and
+ * so the existing link, mention, emoji and image handling stays on its current code path.
+ *
+ * The rules below exist to stop ordinary chat text being mangled. The failure that matters is
+ * not "some markdown went unformatted", it is "a URL or a variable name got eaten", so every
+ * ambiguous case resolves toward leaving the text alone.
+ */
+
+export interface InlineSpan {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  strike?: boolean;
+  code?: boolean;
+}
+
+type Style = Omit<InlineSpan, 'text'>;
+
+const isWordChar = (ch: string | undefined) => !!ch && /[A-Za-z0-9]/.test(ch);
+const isSpace = (ch: string | undefined) => !ch || /\s/.test(ch);
+
+interface Rule {
+  open: string;
+  close: string;
+  style: Style;
+  /** Underscore emphasis must not fire inside a word, so snake_case_names stay intact. */
+  wordBoundary?: boolean;
+  /** Code spans are literal: nothing inside them is parsed further. */
+  literal?: boolean;
+}
+
+// Order matters: longer delimiters first, so ** is not read as two separate * emphases.
+const RULES: Rule[] = [
+  { open: '`', close: '`', style: { code: true }, literal: true },
+  { open: '**', close: '**', style: { bold: true } },
+  { open: '__', close: '__', style: { bold: true }, wordBoundary: true },
+  { open: '~~', close: '~~', style: { strike: true } },
+  { open: '*', close: '*', style: { italic: true } },
+  { open: '_', close: '_', style: { italic: true }, wordBoundary: true },
+];
+
+interface DelimiterMatch {
+  rule: Rule;
+  start: number;
+  contentStart: number;
+  contentEnd: number;
+  end: number;
+}
+
+/**
+ * Finds the first usable delimiter pair at or after `from`.
+ * Returns null when nothing in the remaining text qualifies.
+ *
+ * The return type is annotated explicitly: `best` is assigned inside a callback, which control
+ * flow analysis does not track, so an inferred type collapses to null at the call site.
+ */
+const findMatch = (text: string, from: number): DelimiterMatch | null => {
+  let best: DelimiterMatch | null = null;
+
+  RULES.forEach((rule) => {
+    let searchFrom = from;
+
+    while (searchFrom < text.length) {
+      const start = text.indexOf(rule.open, searchFrom);
+      if (start === -1) {
+        return;
+      }
+
+      const contentStart = start + rule.open.length;
+      // An opening delimiter must be followed by real content, so "2 * 3 * 4" is left alone, and
+      // "_" only opens at a word boundary, so file_name_here is not italicised.
+      const openInvalid =
+        isSpace(text[contentStart]) || (rule.wordBoundary && isWordChar(text[start - 1]));
+
+      if (openInvalid) {
+        // Not a real delimiter here. Step past it and keep scanning for THIS rule: "2 * 3 and
+        // *italic*" must still find the later pair. Abandoning the rule would miss it.
+        searchFrom = start + 1;
+      } else {
+        let closeAt = text.indexOf(rule.close, contentStart);
+        while (closeAt !== -1) {
+          const beforeClose = text[closeAt - 1];
+          const afterClose = text[closeAt + rule.close.length];
+          const closeOk = !isSpace(beforeClose) && !(rule.wordBoundary && isWordChar(afterClose));
+          // Content has to be more than delimiters, so a run like "***" stays literal instead of
+          // formatting a lone "*". Ambiguous punctuation resolves toward leaving text untouched.
+          const hasSubstance = /[^*_~`]/.test(text.slice(contentStart, closeAt));
+          if (closeOk && hasSubstance && closeAt > contentStart) {
+            break;
+          }
+          closeAt = text.indexOf(rule.close, closeAt + 1);
+        }
+
+        // closeAt === -1 means unterminated: leave it literal rather than swallowing the rest.
+        if (closeAt !== -1 && (!best || start < best.start)) {
+          best = {
+            rule,
+            start,
+            contentStart,
+            contentEnd: closeAt,
+            end: closeAt + rule.close.length,
+          };
+        }
+        return;
+      }
+    }
+  });
+
+  return best;
+};
+
+const mergeStyle = (a: Style, b: Style): Style => ({ ...a, ...b });
+
+const parse = (text: string, inherited: Style, depth: number): InlineSpan[] => {
+  if (!text) {
+    return [];
+  }
+
+  // Bounded recursion: pathological delimiter soup should degrade to plain text, not hang.
+  if (depth > 4) {
+    return [{ text, ...inherited }];
+  }
+
+  const match = findMatch(text, 0);
+  if (!match) {
+    return [{ text, ...inherited }];
+  }
+
+  const spans: InlineSpan[] = [];
+  if (match.start > 0) {
+    spans.push({ text: text.slice(0, match.start), ...inherited });
+  }
+
+  const content = text.slice(match.contentStart, match.contentEnd);
+  const style = mergeStyle(inherited, match.rule.style);
+
+  if (match.rule.literal) {
+    spans.push({ text: content, ...style });
+  } else {
+    spans.push(...parse(content, style, depth + 1));
+  }
+
+  spans.push(...parse(text.slice(match.end), inherited, depth));
+
+  return spans.filter((s) => s.text.length > 0);
+};
+
+/**
+ * Splits `text` into styled spans. Always returns at least one span for non-empty input, and
+ * never drops characters: concatenating every `text` yields the input minus the delimiters that
+ * were actually consumed.
+ */
+export const parseInlineMarkdown = (text: string): InlineSpan[] => {
+  if (!text) {
+    return [];
+  }
+  return parse(text, {}, 0);
+};
+
+/** True when the text contains nothing this module would change. Lets callers skip the work. */
+export const hasInlineMarkdown = (text: string): boolean =>
+  !!text &&
+  /[*_~`]/.test(text) &&
+  parseInlineMarkdown(text).some((s) => s.bold || s.italic || s.strike || s.code);

--- a/src/screens/chats/utils/messageFormatters.tsx
+++ b/src/screens/chats/utils/messageFormatters.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Platform, Text } from 'react-native';
 import moment from 'moment';
 import { emojifyMessage } from '../../../utils/emoji';
 import { mattermostToUnicode } from '../../../utils/emojiMapper';
 import { extractImageUrls } from '../../../utils/editor';
 import { getHiveUsernameFromMattermostUser } from '../../../providers/chat/mattermost';
+import { InlineSpan, parseInlineMarkdown } from './inlineMarkdown';
 
 export interface ChatPost {
   id?: string;
@@ -172,6 +173,83 @@ export const setLinkText = (url: string): string => {
 /**
  * Render text with bold @mentions (returns React elements)
  */
+const spanStyle = (span: InlineSpan) => {
+  const style: any = {};
+  if (span.bold) {
+    style.fontWeight = '700';
+  }
+  if (span.italic) {
+    style.fontStyle = 'italic';
+  }
+  if (span.strike) {
+    style.textDecorationLine = 'line-through';
+  }
+  if (span.code) {
+    style.fontFamily = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
+  }
+  return style;
+};
+
+/**
+ * Applies inline markdown to one run of non-mention text.
+ *
+ * Anything covered by a linkify range is passed through as a raw string: the surrounding
+ * <Hyperlink> matches on the rendered text, so splitting a URL into styled <Text> nodes would
+ * stop it being tappable, and a URL containing "_" or "*" could otherwise be reformatted into
+ * something that no longer resolves.
+ */
+const renderSegmentWithMarkdown = (
+  text: string,
+  absoluteStart: number,
+  linkRanges: Array<{ start: number; end: number }>,
+  textStyle: any,
+  keyPrefix: string,
+): React.ReactNode[] => {
+  const absoluteEnd = absoluteStart + text.length;
+  const overlapping = linkRanges
+    .filter((r) => r.end > absoluteStart && r.start < absoluteEnd)
+    .sort((a2, b2) => a2.start - b2.start);
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = absoluteStart;
+
+  const pushFormatted = (from: number, to: number) => {
+    const slice = text.slice(from - absoluteStart, to - absoluteStart);
+    if (!slice) {
+      return;
+    }
+    parseInlineMarkdown(slice).forEach((span, i) => {
+      if (!span.bold && !span.italic && !span.strike && !span.code) {
+        nodes.push(span.text);
+        return;
+      }
+      nodes.push(
+        // eslint-disable-next-line react/no-array-index-key
+        <Text key={`${keyPrefix}md${from}_${i}`} style={[textStyle, spanStyle(span)]}>
+          {span.text}
+        </Text>,
+      );
+    });
+  };
+
+  overlapping.forEach((range) => {
+    const linkStart = Math.max(range.start, absoluteStart);
+    const linkEnd = Math.min(range.end, absoluteEnd);
+    if (linkStart > cursor) {
+      pushFormatted(cursor, linkStart);
+    }
+    // raw string: leave the URL exactly as typed for <Hyperlink>
+    nodes.push(text.slice(linkStart - absoluteStart, linkEnd - absoluteStart));
+    cursor = linkEnd;
+  });
+
+  if (cursor < absoluteEnd) {
+    pushFormatted(cursor, absoluteEnd);
+  }
+
+  return nodes;
+};
+
 export const renderTextWithBoldMentions = (
   text: string,
   textStyle: any,
@@ -184,7 +262,9 @@ export const renderTextWithBoldMentions = (
   }));
 
   const mentionPattern = /(^|[\s\n])(@[a-zA-Z0-9\-.]+)/g;
-  const parts: Array<{ text: string; isMention: boolean }> = [];
+  // `start` is the absolute offset into `text`, needed so inline markdown can be skipped
+  // wherever a linkify range covers the run.
+  const parts: Array<{ text: string; isMention: boolean; start: number }> = [];
   let lastIndex = 0;
   let match;
 
@@ -200,24 +280,25 @@ export const renderTextWithBoldMentions = (
     );
 
     if (match.index > lastIndex) {
-      parts.push({ text: text.slice(lastIndex, match.index), isMention: false });
+      parts.push({ text: text.slice(lastIndex, match.index), isMention: false, start: lastIndex });
     }
 
     if (beforeChar) {
-      parts.push({ text: beforeChar, isMention: false });
+      parts.push({ text: beforeChar, isMention: false, start: match.index });
     }
 
-    parts.push({ text: mention, isMention: !isInsideLink });
+    parts.push({ text: mention, isMention: !isInsideLink, start: mentionStart });
 
     lastIndex = match.index + fullMatch.length;
   }
 
   if (lastIndex < text.length) {
-    parts.push({ text: text.slice(lastIndex), isMention: false });
+    parts.push({ text: text.slice(lastIndex), isMention: false, start: lastIndex });
   }
 
+  // No mentions is the common case, and it still needs inline markdown applied.
   if (parts.length === 0) {
-    return text;
+    return renderSegmentWithMarkdown(text, 0, linkRanges, textStyle, 'p');
   }
 
   return parts.map((part, index) => {
@@ -229,6 +310,6 @@ export const renderTextWithBoldMentions = (
         </Text>
       );
     }
-    return part.text;
+    return renderSegmentWithMarkdown(part.text, part.start, linkRanges, textStyle, `s${index}_`);
   });
 };

--- a/src/screens/chats/utils/messageMarkdown.test.tsx
+++ b/src/screens/chats/utils/messageMarkdown.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { renderTextWithBoldMentions } from './messageFormatters';
+
+/**
+ * Guards the integration, not the parser (inlineMarkdown.test.ts covers that).
+ *
+ * The property that matters here is that a URL is handed to <Hyperlink> as an untouched raw
+ * string. Splitting one into styled <Text> nodes would stop it being tappable, and a URL
+ * containing "_" could otherwise be reformatted into something that no longer resolves.
+ */
+
+/** Minimal stand-in for the linkify instance the chat screen passes in. */
+const linkify = (urls: string[]) => ({
+  match: (text: string) => {
+    const found: Array<{ index: number; raw: string }> = [];
+    urls.forEach((u) => {
+      const i = text.indexOf(u);
+      if (i !== -1) {
+        found.push({ index: i, raw: u });
+      }
+    });
+    return found.length ? found : null;
+  },
+});
+
+type Node = React.ReactElement | string;
+
+const nodes = (out: React.ReactNode): Node[] => (Array.isArray(out) ? out.flat(3) : [out as Node]);
+
+/** Concatenates all text, whether it came back as a raw string or inside a <Text>. */
+const allText = (out: React.ReactNode): string =>
+  nodes(out)
+    .map((n) => (typeof n === 'string' ? n : (n as any)?.props?.children ?? ''))
+    .join('');
+
+/** The raw strings only — these are what <Hyperlink> can still see and linkify. */
+const rawStrings = (out: React.ReactNode): string[] =>
+  nodes(out).filter((n): n is string => typeof n === 'string');
+
+const styledNodes = (out: React.ReactNode) =>
+  nodes(out).filter((n) => typeof n !== 'string') as React.ReactElement[];
+
+const styleOf = (el: React.ReactElement) => {
+  const s = (el.props as any).style;
+  return Object.assign({}, ...(Array.isArray(s) ? s.flat(3) : [s]).filter(Boolean));
+};
+
+describe('chat message rendering — links are never reformatted', () => {
+  it('keeps a URL with underscores as one raw string', () => {
+    const url = 'https://ecency.com/@user/my_great_post_here';
+    const out = renderTextWithBoldMentions(`look at ${url} please`, {}, linkify([url]));
+
+    expect(rawStrings(out).join('')).toContain(url);
+    expect(allText(out)).toBe(`look at ${url} please`);
+    expect(styledNodes(out)).toHaveLength(0);
+  });
+
+  it('formats markdown around a link without touching the link', () => {
+    const url = 'https://ecency.com/@user/post_one';
+    const out = renderTextWithBoldMentions(`**wow** see ${url} now`, {}, linkify([url]));
+
+    expect(rawStrings(out).join('')).toContain(url);
+    const styled = styledNodes(out);
+    expect(styled).toHaveLength(1);
+    expect((styled[0].props as any).children).toBe('wow');
+    expect(styleOf(styled[0]).fontWeight).toBe('700');
+  });
+
+  it('does not italicise asterisks that live inside a URL', () => {
+    const url = 'https://example.com/a*b*c';
+    const out = renderTextWithBoldMentions(`link ${url} end`, {}, linkify([url]));
+
+    expect(rawStrings(out).join('')).toContain(url);
+    expect(styledNodes(out)).toHaveLength(0);
+  });
+});
+
+describe('chat message rendering — markdown and mentions coexist', () => {
+  it('applies markdown when there are no mentions at all', () => {
+    const out = renderTextWithBoldMentions('this is **important**', {}, linkify([]));
+    const styled = styledNodes(out);
+
+    expect(styled).toHaveLength(1);
+    expect((styled[0].props as any).children).toBe('important');
+    expect(allText(out)).toBe('this is important');
+  });
+
+  it('keeps mentions bold alongside markdown', () => {
+    const out = renderTextWithBoldMentions('hey @rainkiss this is *urgent*', {}, linkify([]));
+    const styled = styledNodes(out);
+
+    const mention = styled.find((n) => (n.props as any).children === '@rainkiss');
+    const italic = styled.find((n) => (n.props as any).children === 'urgent');
+
+    expect(mention).toBeTruthy();
+    expect(styleOf(mention!).fontWeight).toBe('700');
+    expect(italic).toBeTruthy();
+    expect(styleOf(italic!).fontStyle).toBe('italic');
+    expect(allText(out)).toBe('hey @rainkiss this is urgent');
+  });
+
+  it('leaves an ordinary message completely untouched', () => {
+    const plain = 'just saying hello everyone';
+    const out = renderTextWithBoldMentions(plain, {}, linkify([]));
+
+    expect(allText(out)).toBe(plain);
+    expect(styledNodes(out)).toHaveLength(0);
+  });
+
+  it('does not format snake_case in ordinary chat', () => {
+    const out = renderTextWithBoldMentions('the file_name_here is set', {}, linkify([]));
+
+    expect(allText(out)).toBe('the file_name_here is set');
+    expect(styledNodes(out)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Part of #3468, scoped to the inline subset (see the issue comment for why block-level parity was deferred).

## What renders now

`**bold**`, `*italic*` / `_italic_`, `~~strike~~`, `` `code` `` — as nested `<Text>`. Block constructs are deliberately untouched, so a message starting with `-` or `#` still reads the way it was typed, and the existing link, mention, emoji and image handling stays on its current code path.

## The design constraint

The risk is not missing formatting, it is mangling ordinary chat. Every ambiguous case resolves toward leaving text alone:

| input | result |
| --- | --- |
| `file_name_here` | untouched — `_` does not open inside a word |
| `2 * 3 * 4 = 24` | untouched — a delimiter followed by space does not open |
| `*hello there` | untouched — unterminated delimiters stay literal |
| `***` | untouched — a span of only delimiters does not format |
| `` `a **b** c` `` | code span, contents literal |

## URLs get a second, independent guard

Anything inside a linkify range is passed through as a raw string, so a URL is never split into styled nodes and stays tappable via `<Hyperlink>`. This matters because a URL containing `_` could otherwise be reformatted into something that no longer resolves.

The two defences are independent, which I verified by removing the link-range guard: the underscore cases still passed on the parser rule alone, and only the `a*b*c` URL case failed. Both are kept.

## Tests

23 new. The parser is covered directly; a separate integration spec covers the wiring, since the parser being right does not prove the renderer uses it correctly.

One regression is pinned specifically: an invalid opening delimiter must keep scanning the same rule rather than abandoning it, so `2 * 3 and *italic*` still finds the real pair. I broke exactly this while removing a `continue` for the lint rule, and the test now catches it.

## Checks

`typecheck ok: 0 errors (baseline 0)`. Full suite 790 passed / 55 suites. Lint clean on the chat directory (0 errors; 25 pre-existing warnings unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rich text formatting in chat messages, including bold, italic, strikethrough, and inline code.
  - Preserved tappable links and correctly handled mentions alongside formatted text.
  - Improved handling of ambiguous, incomplete, and nested formatting syntax.

- **Tests**
  - Added comprehensive coverage for formatting, links, mentions, edge cases, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->