### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.80",
+    "@ecency/sdk": "^2.3.81",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.80":
-  version "2.3.80"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.80.tgz#e285dd3f9523ed5d7ff2d663c2270c36a0e209c5"
-  integrity sha512-5rYRxXt+iKAHX6CPi3m2KZACGyszKzsMthv1kjZa/yy8K1EtzyMCYk0t+mIxRH+XTZ9LIOCgKj3Q/sFA8gTfkQ==
+"@ecency/sdk@^2.3.81":
+  version "2.3.81"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.81.tgz#45114b24a2034558b8b660b3d00e57f8e0f76847"
+  integrity sha512-Cts5FRcrYYSpHeTbTAqd4M1/CQJWzxulNUDn+4G4gFz15sXnI9gibpP07KRkmptaTqUO2tpwOTS5g72mZM8Sdg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` from 2.3.80 to 2.3.81, which is the release of ecency/vision-web#1404.

#3480 landed on 2.3.80, so it has the pagination direction fix but not these two follow-ups:

- **The walk could not reach the head of history.** `condenser_api.get_account_history` asserts `start >= limit - 1`. The cursor is derived from `num` alone, so the last window before the start of history was shorter than `limit` and the request failed the assert rather than returning the remaining rows. The SDK now narrows the requested `limit` for that final window.
- **`fill_transfer_from_savings` ignored the per-asset filter.** It had no case in the HIVE/HBD `select` switches, so filtering for it on HIVE also listed completed HBD withdrawals, and the reverse. It now carries the same symbol guard as `transfer_from_savings`.

Both are transparent to callers, so nothing in the app changes beyond the dependency.

## Verification

- `yarn.lock` moves only the `@ecency/sdk` entry, nothing else re-resolved.
- Installed tree confirmed on 2.3.81 and carrying the fix.
- `tsc --noEmit` — 1 error, `src/components/imageViewer/imageViewer.tsx(176,7)`, `doubleTapScale` not on `Props`. Pre-existing: a clean install of `development` at 2.3.80 reports the same single error, so it is unrelated to this bump. Worth a separate issue.
- The four `has no exported member` errors seen against an older locally-installed SDK are gone once the tree matches the lockfile.
