### PR TITLE
chore(deps): bump @ecency/sdk to 2.3.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.81",
+    "@ecency/sdk": "^2.3.82",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.81":
-  version "2.3.81"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.81.tgz#45114b24a2034558b8b660b3d00e57f8e0f76847"
-  integrity sha512-Cts5FRcrYYSpHeTbTAqd4M1/CQJWzxulNUDn+4G4gFz15sXnI9gibpP07KRkmptaTqUO2tpwOTS5g72mZM8Sdg==
+"@ecency/sdk@^2.3.82":
+  version "2.3.82"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.82.tgz#74e9cfcb278de2f810446262c3516db539c8340d"
+  integrity sha512-8kYahuQ8CcCDimKsze22GXCziyv4fQDAyshj8QYQEySVFiMj0sHU06F2g0IZ+tg+pufpcImp55JQae+a65naYQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Bumps `@ecency/sdk` from 2.3.81 to 2.3.82, the release of ecency/vision-web#1407 (issue ecency/vision-web#1403).

## What it fixes

An account name is a `fixed_string` of 16 **bytes**, and hived asserts on the byte length while deserialising the argument, before it looks anything up. So an over-long value is not answered with "no such account", it is answered with

```
Assert Exception:in_len <= sizeof(data): Input too large: `<value>` (17) for fixed size string: (16)
```

That applies to plain reads, not only to broadcasts, because `lookup_accounts`, `get_accounts` and `get_account_reputations` all take an `account_name_type`. The SDK now resolves those to no matches instead of making the call, and `get_accounts` drops only the offending entries so one bad name no longer takes down the whole batch.

Worth knowing when writing account-name checks here: the limit is bytes, not characters. `sebastián.bilbao` is 16 characters and 17 bytes, `вцпк33ппп43` is 11 characters and 18 bytes, and the node rejects both. A `.length <= 16` check passes them.

## Verification

- `yarn.lock` moves only the `@ecency/sdk` entry, nothing else re-resolved.
- Installed tree confirmed on 2.3.82, and the guard exercised through the published bundle rather than assumed:

```
"good-karma"        -> true
"aliveandthriving"  -> true    (exactly 16 bytes)
"aliveandthriving," -> false
"sebastián.bilbao"  -> false
"вцпк33ппп43"       -> false
```

- `tsc --noEmit` — 1 error, `src/components/imageViewer/imageViewer.tsx(176,7)`, `doubleTapScale` not on `Props`. Pre-existing and unrelated: a clean install of `development` reports the identical single error at 2.3.80 and at 2.3.81. Still worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ecency SDK dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->