### PR TITLE
Pre-release hardening: parseAsset, sheet model, navigation contract, delete default

### DIFF
--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -6,7 +6,7 @@ import { Alert } from 'react-native';
 import { SheetManager } from 'react-native-actions-sheet';
 import { getMutedUsersQueryOptions, getNotificationsUnreadCountQueryOptions } from '@ecency/sdk';
 import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
-import { AppParamList, RouteName } from '../../../navigation/types';
+import { NavigateArgs, RouteName } from '../../../navigation/types';
 
 import { setPrevLoggedInUsers, updateCurrentAccount } from '../../../redux/actions/accountAction';
 
@@ -67,7 +67,7 @@ const AccountsBottomSheetContainer = () => {
     }
   };
 
-  const _navigateToRoute = <K extends RouteName>(name: K, params?: AppParamList[K]) => {
+  const _navigateToRoute = <K extends RouteName>(...[name, params]: NavigateArgs<K>) => {
     SheetManager.hide(SheetNames.ACCOUNTS_SHEET);
     accountsBottomSheetViewRef.current?.closeAccountsBottomSheet();
     if (name) {

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -5,7 +5,8 @@ import { useIntl } from 'react-intl';
 import { Alert } from 'react-native';
 import { SheetManager } from 'react-native-actions-sheet';
 import { getMutedUsersQueryOptions, getNotificationsUnreadCountQueryOptions } from '@ecency/sdk';
-import RootNavigation from '../../../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
+import { AppParamList, RouteName } from '../../../navigation/types';
 
 import { setPrevLoggedInUsers, updateCurrentAccount } from '../../../redux/actions/accountAction';
 
@@ -66,11 +67,12 @@ const AccountsBottomSheetContainer = () => {
     }
   };
 
-  const _navigateToRoute = (name: string, params: any) => {
+  const _navigateToRoute = <K extends RouteName>(name: K, params?: AppParamList[K]) => {
     SheetManager.hide(SheetNames.ACCOUNTS_SHEET);
     accountsBottomSheetViewRef.current?.closeAccountsBottomSheet();
     if (name) {
-      RootNavigation.navigate({ name, params });
+      // Correlated by the generic at the call site; TS cannot re-derive that pairing here.
+      RootNavigation.navigate({ name, params } as NavigateOptions);
     }
   };
 

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetView.tsx
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetView.tsx
@@ -15,6 +15,7 @@ import HiveAuthIconSource from '../../../assets/HiveAuth_logo.png';
 import HiveIconSource from '../../../assets/hive_icon.png';
 
 import { default as ROUTES } from '../../../constants/routeNames';
+import { AppParamList, RouteName } from '../../../navigation/types';
 
 import styles from './accountsBottomSheetStyles';
 
@@ -26,7 +27,7 @@ export interface AccountsBottomSheetRef {
 export interface AccountsBottomSheetProps {
   accounts: any[];
   currentAccount: any;
-  navigateToRoute: (route: string, params?: any) => void;
+  navigateToRoute: <K extends RouteName>(route: K, params?: AppParamList[K]) => void;
   switchAccount: (account: any) => void;
   prevLoggedInUsers: Array<any>;
   dispatch: (action: any) => void;

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetView.tsx
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetView.tsx
@@ -15,7 +15,7 @@ import HiveAuthIconSource from '../../../assets/HiveAuth_logo.png';
 import HiveIconSource from '../../../assets/hive_icon.png';
 
 import { default as ROUTES } from '../../../constants/routeNames';
-import { AppParamList, RouteName } from '../../../navigation/types';
+import { NavigateArgs, RouteName } from '../../../navigation/types';
 
 import styles from './accountsBottomSheetStyles';
 
@@ -27,7 +27,7 @@ export interface AccountsBottomSheetRef {
 export interface AccountsBottomSheetProps {
   accounts: any[];
   currentAccount: any;
-  navigateToRoute: <K extends RouteName>(route: K, params?: AppParamList[K]) => void;
+  navigateToRoute: <K extends RouteName>(...args: NavigateArgs<K>) => void;
   switchAccount: (account: any) => void;
   prevLoggedInUsers: Array<any>;
   dispatch: (action: any) => void;

--- a/src/components/aiAssistModal/aiAssistModal.tsx
+++ b/src/components/aiAssistModal/aiAssistModal.tsx
@@ -52,7 +52,8 @@ export const AiAssistModal = ({ payload }: SheetProps<SheetNames.AI_ASSIST>) => 
   const [result, setResult] = useState<{ output: string; action: AiAssistAction } | null>(null);
   const [selectedTitleIndex, setSelectedTitleIndex] = useState(0);
 
-  // Reset state when payload changes (sheets stay mounted)
+  // Sheets mount on show, so this seeds the input on every open. The `payload` dep additionally
+  // covers a re-show onto a still-mounted sheet.
   useEffect(() => {
     const newText = payload?.text?.slice(0, MAX_INPUT) || '';
     setText(newText);

--- a/src/components/balanceAnalyticsSheet/balanceAnalyticsSheet.tsx
+++ b/src/components/balanceAnalyticsSheet/balanceAnalyticsSheet.tsx
@@ -83,10 +83,9 @@ const BalanceAnalyticsSheet = ({ payload }: SheetProps<SheetNames.BALANCE_ANALYT
   const [activeTab, setActiveTab] = useState<Tab>('history');
   const [granularity, setGranularity] = useState<Granularity>('yearly');
 
-  // Action sheets stay mounted between presentations (per CLAUDE.md
-  // sheet-pattern note), so reset our local view state whenever the sheet is
-  // re-opened with a new payload — otherwise the previous account/coin's tab
-  // and granularity selection leak into the new view.
+  // Sheets mount on show, so useState already seeds these on a normal open. This effect covers
+  // a re-show onto a still-mounted sheet with a different account/coin, whose tab and
+  // granularity selection would otherwise leak into the new view.
   useEffect(() => {
     setActiveTab('history');
     setGranularity('yearly');

--- a/src/components/communityRoleEditSheet/communityRoleEditSheet.tsx
+++ b/src/components/communityRoleEditSheet/communityRoleEditSheet.tsx
@@ -94,9 +94,9 @@ const CommunityRoleEditSheet: React.FC<SheetProps<'community_role_edit'>> = ({
     setError('');
   }, [payload?.account]);
 
-  // Registered sheets stay mounted, and resetting on payload identity alone is
-  // not enough when the same payload object is reused, so reset on every
-  // presentation.
+  // Sheets mount on show, so mounting is what guarantees the reset on every presentation. The
+  // `payload` dep only covers a re-show onto a still-mounted sheet, and it cannot be relied on
+  // alone: a caller reusing the same payload object would not re-fire it.
   useEffect(() => {
     _reset();
   }, [payload, _reset]);

--- a/src/components/composeTranslateModal/composeTranslateModal.tsx
+++ b/src/components/composeTranslateModal/composeTranslateModal.tsx
@@ -130,8 +130,13 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   // A result translated into a previous language pair must never be applied. Retiring the run
   // is what enforces that: clearing the state alone loses the race against a run still in
   // flight, which would write its result back a moment later.
+  //
+  // Clearing `translating` is part of retiring it. The run being cancelled can no longer do it
+  // itself, because every write it makes is now gated on still being current, and a stuck
+  // `translating` leaves the spinner up with both action buttons disabled.
   useEffect(() => {
     runIdRef.current += 1;
+    setTranslating(false);
     setTranslated('');
     setFailed(false);
   }, [source, target]);

--- a/src/components/composeTranslateModal/composeTranslateModal.tsx
+++ b/src/components/composeTranslateModal/composeTranslateModal.tsx
@@ -56,10 +56,16 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   const [progress, setProgress] = useState<[number, number]>([0, 0]);
   const [failed, setFailed] = useState(false);
 
-  // Cancels the in-flight translation chain once the sheet is gone, so it stops paging the
-  // translation service in the background. The chain outlives the component either way, so this
-  // is set from both onClose and unmount rather than trusting onClose to be the only exit.
-  const closedRef = useRef(false);
+  // Identifies the current translation run. A run is superseded by closing the sheet, by
+  // unmount, by a re-show carrying a new payload, by changing the language pair, and by
+  // starting another translation. translateMarkdown pages the service request by request and
+  // only consults its cancel callback between pages, so a run always has to be assumed still
+  // in flight: everything it writes back is gated on still being the current run.
+  //
+  // A plain "closed" flag was not enough. It was cleared again on re-show, and the result
+  // handler did not consult it at all, so a run that resolved after the user switched target
+  // language applied its result to the new pair, defeating the reset below.
+  const runIdRef = useRef(0);
 
   const sample = useMemo(
     () =>
@@ -73,19 +79,19 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   );
   const tooShort = sample.trim().length < MIN_TRANSLATE_CHARS;
 
-  // Sheets unmount on hide, so the chain has to be cancelled here as well: onClose is not
-  // guaranteed to be the route the sheet leaves by, and a chain left running keeps paging the
+  // Sheets unmount on hide, so the run has to be retired here as well: onClose is not
+  // guaranteed to be the route the sheet leaves by, and a run left current keeps paging the
   // translation service for a screen the user has already dismissed.
   useEffect(
     () => () => {
-      closedRef.current = true;
+      runIdRef.current += 1;
     },
     [],
   );
 
   // Sheets mount on show, so this resets state and re-detects the source language on every open.
   useEffect(() => {
-    closedRef.current = false;
+    runIdRef.current += 1;
     setTranslated('');
     setFailed(false);
     setTranslating(false);
@@ -121,8 +127,11 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
     setTarget(reader && reader !== 'en' && LIBRETRANSLATE_TARGETS.has(reader) ? reader : 'es');
   }, [source, appLang]);
 
-  // A result translated into a previous language pair must never be applied.
+  // A result translated into a previous language pair must never be applied. Retiring the run
+  // is what enforces that: clearing the state alone loses the race against a run still in
+  // flight, which would write its result back a moment later.
   useEffect(() => {
+    runIdRef.current += 1;
     setTranslated('');
     setFailed(false);
   }, [source, target]);
@@ -141,6 +150,10 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   );
 
   const _translate = async () => {
+    runIdRef.current += 1;
+    const runId = runIdRef.current;
+    const isCurrent = () => runIdRef.current === runId;
+
     setTranslating(true);
     setFailed(false);
     setTranslated('');
@@ -150,17 +163,23 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
         body,
         source,
         target,
-        (done, total) => setProgress([done, total]),
-        () => closedRef.current,
+        (done, total) => {
+          if (isCurrent()) {
+            setProgress([done, total]);
+          }
+        },
+        () => !isCurrent(),
       );
-      setTranslated(result);
+      if (isCurrent()) {
+        setTranslated(result);
+      }
     } catch (error) {
       console.log('translate error : ', error);
-      if (!closedRef.current) {
+      if (isCurrent()) {
         setFailed(true);
       }
     } finally {
-      if (!closedRef.current) {
+      if (isCurrent()) {
         setTranslating(false);
       }
     }
@@ -183,7 +202,7 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   };
 
   const _handleOnSheetClose = () => {
-    closedRef.current = true;
+    runIdRef.current += 1;
     setTranslating(false);
   };
 

--- a/src/components/composeTranslateModal/composeTranslateModal.tsx
+++ b/src/components/composeTranslateModal/composeTranslateModal.tsx
@@ -56,8 +56,9 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   const [progress, setProgress] = useState<[number, number]>([0, 0]);
   const [failed, setFailed] = useState(false);
 
-  // Sheets stay mounted; a closed sheet cancels the request chain so it stops
-  // hitting the translation service in the background.
+  // Cancels the in-flight translation chain once the sheet is gone, so it stops paging the
+  // translation service in the background. The chain outlives the component either way, so this
+  // is set from both onClose and unmount rather than trusting onClose to be the only exit.
   const closedRef = useRef(false);
 
   const sample = useMemo(
@@ -72,8 +73,17 @@ export const ComposeTranslateModal = ({ payload }: SheetProps<SheetNames.COMPOSE
   );
   const tooShort = sample.trim().length < MIN_TRANSLATE_CHARS;
 
-  // Reset state and re-detect the source language on every open (payload is a
-  // fresh object per SheetManager.show).
+  // Sheets unmount on hide, so the chain has to be cancelled here as well: onClose is not
+  // guaranteed to be the route the sheet leaves by, and a chain left running keeps paging the
+  // translation service for a screen the user has already dismissed.
+  useEffect(
+    () => () => {
+      closedRef.current = true;
+    },
+    [],
+  );
+
+  // Sheets mount on show, so this resets state and re-detects the source language on every open.
   useEffect(() => {
     closedRef.current = false;
     setTranslated('');

--- a/src/components/foregroundNotification/foregroundNotification.tsx
+++ b/src/components/foregroundNotification/foregroundNotification.tsx
@@ -128,31 +128,23 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
     const { data } = remoteMessage;
     const { type } = data;
 
-    let routeName;
-    let params;
-    let key;
-
     if (type === 'transfer' || type === 'delegations') {
       // Navigate to wallet for financial transactions
-      routeName = ROUTES.TABBAR.WALLET;
+      RootNavigation.navigate({ name: ROUTES.TABBAR.WALLET });
     } else {
       // Navigate to post for reply/mention
       const fullPermlink =
         get(data, 'permlink1', '') + get(data, 'permlink2', '') + get(data, 'permlink3', '');
 
-      params = {
-        author: get(data, 'source', ''),
-        permlink: fullPermlink,
-      };
-      key = fullPermlink;
-      routeName = ROUTES.SCREENS.POST;
+      RootNavigation.navigate({
+        name: ROUTES.SCREENS.POST,
+        params: {
+          author: get(data, 'source', ''),
+          permlink: fullPermlink,
+        },
+        key: fullPermlink,
+      });
     }
-
-    RootNavigation.navigate({
-      name: routeName,
-      params,
-      key,
-    });
     hide();
   };
 

--- a/src/components/iconButton/view/iconButtonView.tsx
+++ b/src/components/iconButton/view/iconButtonView.tsx
@@ -1,5 +1,12 @@
 import React, { Fragment } from 'react';
-import { TouchableOpacity, ActivityIndicator, StyleProp, TextStyle, ViewStyle } from 'react-native';
+import {
+  TouchableOpacity,
+  TouchableOpacityProps,
+  ActivityIndicator,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { Icon } from '../../icon';
 
@@ -23,6 +30,9 @@ interface IconButtonProps {
   isLoading?: boolean;
   iconStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
+  // The button is a fixed 30x30, below the 44pt guideline. Opt in per call site where a
+  // mis-tap is costly, rather than changing the hit area of every icon button at once.
+  hitSlop?: TouchableOpacityProps['hitSlop'];
   onPress?: (event?: any) => void;
   onLongPress?: (event?: any) => void;
   accessibilityLabel?: string;
@@ -46,10 +56,12 @@ const IconButton = ({
   isLoading,
   accessibilityLabel,
   accessibilityHint,
+  hitSlop,
 }: IconButtonProps) => (
   <Fragment>
     <TouchableOpacity
       style={[styles.iconButton, style]}
+      hitSlop={hitSlop}
       onPress={() => !isLoading && onPress && onPress()}
       disabled={disabled}
       onLongPress={() => !isLoading && onLongPress && onLongPress()}

--- a/src/components/post-translation-modal/postTranslationModal.tsx
+++ b/src/components/post-translation-modal/postTranslationModal.tsx
@@ -47,11 +47,9 @@ const PostTranslationModal = ({ payload }: SheetProps<'post_translation'>) => {
     getSupportedLanguages();
   }, []);
 
-  // Sheets stay mounted and _handleOnSheetClose resets the target on close, so
-  // re-apply the pre-selected target/source on EVERY open. Keying on `payload`
-  // (a fresh object per SheetManager.show) is what makes this re-fire when the
-  // sheet is reopened from the same chip/banner with unchanged initial codes —
-  // without it the pre-targeting would only work once per session.
+  // Sheets mount on show, so this applies the pre-selected target/source on every open. It has
+  // to run again once the language list resolves, which is why the list is a dependency: on the
+  // first open the codes arrive before the list and there is nothing to match them against yet.
   useEffect(() => {
     if (!supportedLangsList.length) {
       return;

--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -73,13 +73,11 @@ const CommentBody = ({
         return;
       }
       const name = isCommunity(tag) ? ROUTES.SCREENS.COMMUNITY : ROUTES.SCREENS.TAG_RESULT;
-      const key = `${filter}/${tag}`;
       RootNavigation.navigate({
         name,
         params: {
           tag,
           filter,
-          key,
         },
       });
     }

--- a/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.tsx
@@ -13,7 +13,7 @@ import styles from './postHeaderDescriptionStyles';
 
 import { default as ROUTES } from '../../../../constants/routeNames';
 import { IconButton } from '../../..';
-import RootNavigation from '../../../../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../../../../navigation/rootNavigation';
 
 // Constants
 
@@ -69,7 +69,9 @@ class PostHeaderDescription extends PureComponent<any, any> {
 
   _handleOnTagPress = (content: any) => {
     const { handleTagPress } = this.props;
-    let navParams = {};
+    // Stays undefined when `content` matches none of the branches below, which previously fell
+    // through to navigate({}).
+    let navParams: NavigateOptions | undefined;
     if (content && content.category && /hive-[1-3]\d{4,6}$/.test(content.category)) {
       navParams = {
         name: ROUTES.SCREENS.COMMUNITY,
@@ -101,6 +103,10 @@ class PostHeaderDescription extends PureComponent<any, any> {
           tag: content,
         },
       };
+    }
+
+    if (!navParams) {
+      return;
     }
 
     if (handleTagPress) {

--- a/src/components/postOptionsModal/container/postOptionsModal.tsx
+++ b/src/components/postOptionsModal/container/postOptionsModal.tsx
@@ -77,6 +77,19 @@ interface Props {
    */
   onDelete?: (content: any) => void | Promise<void>;
   /**
+   * Set only by consumers whose content *is* the screen, which today means postScreen alone, so
+   * that deleting it pops back. Everything else owns a surrounding list and must not pop.
+   *
+   * This is an opt-in rather than a default because the two failure modes are not symmetric.
+   * Forgetting it leaves the user on the screen, which is mildly wrong and obvious in testing.
+   * Popping by default navigated the user away from a list they were reading, which is badly
+   * wrong and easy to miss: it shipped three times (waves, the comment surfaces in #3405/#3406,
+   * the feed list in #3407). Content shape cannot decide this, because postScreen renders
+   * comments and waves as primary content, so a comment in a list and a comment as the screen
+   * are the same object (#3408, reverted).
+   */
+  popScreenOnDelete?: boolean;
+  /**
    * Optional thread handler. When provided, the "open-thread" action is offered
    * and delegates here. Only comment surfaces can open a thread, so the option
    * is hidden wherever this is absent.
@@ -85,7 +98,7 @@ interface Props {
 }
 
 const PostOptionsModal = (
-  { pageType, isWave, isVisibleTranslateModal, onDelete, onOpenThread }: Props,
+  { pageType, isWave, isVisibleTranslateModal, onDelete, popScreenOnDelete, onOpenThread }: Props,
   ref: any,
 ) => {
   const intl = useIntl();
@@ -487,15 +500,12 @@ const PostOptionsModal = (
           parentAuthor: content.parent_author || '',
           parentPermlink: content.parent_permlink || '',
         });
-        // Always pops, because only the caller knows whether the deleted content
-        // *is* the screen. postScreen renders comments and waves as primary
-        // content too, so `parent_author` cannot stand in for that: gating on it
-        // left a comment's own detail screen showing deleted content.
-        //
-        // Consumers that own a surrounding list must therefore pass `onDelete`
-        // and handle removal themselves. See #3407 for inverting this into an
-        // explicit opt-in, which fails safe in the other direction.
-        navigation.goBack();
+        // Only the caller knows whether the deleted content *is* the screen, so popping is
+        // opt-in. Forgetting the opt-in leaves the user where they were; the old default
+        // navigated them off a screen they were still reading.
+        if (popScreenOnDelete) {
+          navigation.goBack();
+        }
         dispatch(
           toastNotification(
             intl.formatMessage({

--- a/src/components/qrModal/qrModalView.tsx
+++ b/src/components/qrModal/qrModalView.tsx
@@ -39,9 +39,9 @@ export const QRModal = ({ sheetId, payload }: SheetProps<SheetNames.QR_SCAN>) =>
     },
   });
 
-  // Registered sheets stay mounted across hide/show, so re-arm the camera and clear
-  // the one-shot scan latch on every open (keyed on `payload`) — not just on mount —
-  // otherwise the scanner stays frozen and silently drops scans after the first one.
+  // Sheets mount on show and unmount on hide, so this arms the camera and clears the one-shot
+  // scan latch on every open. The `payload` dep additionally covers a re-show onto a sheet that
+  // is still mounted, where the scanner would otherwise stay frozen and drop every later scan.
   useEffect(() => {
     requestCameraPermission();
     handledRef.current = false;

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -16,7 +16,7 @@ import { getFormattedTx, isHiveUri, normalizeHiveUri } from '../utils/hive-uri';
 import { resolveTxRequiredAuthority } from '../utils/hiveOperationAuthority';
 import { deepLinkParser } from '../utils/deepLinkParser';
 import showLoginAlert from '../utils/showLoginAlert';
-import RootNavigation from '../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../navigation/rootNavigation';
 import ROUTES from '../constants/routeNames';
 import { delay } from '../utils/editor';
 import { SheetNames } from '../navigation/sheets';
@@ -512,15 +512,11 @@ export const useLinkProcessor = (onClose?: () => void) => {
           RootNavigation.navigate({
             name: ROUTES.SCREENS.PINCODE,
             params: {
-              accessToken: result.accessToken,
               navigateTo: ROUTES.DRAWER.MAIN,
             },
           });
         } else {
-          RootNavigation.navigate({
-            name: ROUTES.DRAWER.MAIN,
-            params: { accessToken: result.accessToken },
-          });
+          RootNavigation.navigate({ name: ROUTES.DRAWER.MAIN });
         }
 
         dispatch(toastNotification(intl.formatMessage({ id: 'alert.successful' })));
@@ -733,7 +729,10 @@ export const useLinkProcessor = (onClose?: () => void) => {
     if (name && params && key) {
       onClose && onClose();
       await delay(500);
-      RootNavigation.navigate(deepLinkData);
+      // `name` is a checked RouteName, but it is still the whole union here, so TS cannot pair
+      // it with `params`. The pairing is enforced inside deepLinkParser, at the branch that
+      // builds each route.
+      RootNavigation.navigate({ name, params, key } as NavigateOptions);
     } else {
       // Open unsupported links in in-app browser
       onClose && onClose();

--- a/src/navigation/rootNavigation.tsx
+++ b/src/navigation/rootNavigation.tsx
@@ -1,14 +1,33 @@
-import { createNavigationContainerRef } from '@react-navigation/native';
+import { createNavigationContainerRef, NavigationContainerRef } from '@react-navigation/native';
+import { AppParamList, ParamsOptional, RouteName } from './types';
 
-export const navigationRef = createNavigationContainerRef();
+export const navigationRef = createNavigationContainerRef<AppParamList>();
 
-const navigate = (navigationProps: any) => {
+/**
+ * The object form of navigate, typed against AppParamList so a wrong route name or a params
+ * object that does not match the destination is a compile error. This matters most on the paths
+ * that reach it: deep-link dispatch, the PIN screen's forwarding, wallet and asset details.
+ *
+ * `params` is optional only where the destination is navigable without them. React Navigation's
+ * own object overload declares `params` as required even when its type includes undefined, which
+ * would reject the many `{ name }`-only calls here, so the optionality is derived instead.
+ */
+export type NavigateOptions = {
+  [K in RouteName]: ParamsOptional<K> extends true
+    ? { name: K; params?: AppParamList[K]; key?: string; merge?: boolean }
+    : { name: K; params: AppParamList[K]; key?: string; merge?: boolean };
+}[RouteName];
+
+type ResetState = Parameters<NavigationContainerRef<AppParamList>['reset']>[0];
+
+const navigate = (navigationProps: NavigateOptions) => {
   if (navigationRef.isReady()) {
-    (navigationRef as any).navigate(navigationProps);
+    // The union has already been checked above; React Navigation's overload cannot narrow it.
+    navigationRef.navigate(navigationProps as never);
   }
 };
 
-const reset = (navigationProps: any) => {
+const reset = (navigationProps: ResetState) => {
   if (navigationRef.isReady()) {
     navigationRef.reset(navigationProps);
   }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -11,11 +11,32 @@ export type RouteName =
   | ValueOf<typeof ROUTES.STACK>;
 
 /**
+ * True when a route is navigable without params.
+ *
+ * PINCODE is answered without probing its params: AppParamList[PINCODE] is PinCodeParams, which
+ * embeds ForwardedNavigation, so evaluating `undefined extends AppParamList[PINCODE]` makes both
+ * types circular. It is navigable without params, so the short-circuit is also the right answer.
+ * Referencing AppParamList[K] in a property position stays lazy and is fine.
+ */
+export type ParamsOptional<K extends RouteName> = K extends typeof ROUTES.SCREENS.PINCODE
+  ? true
+  : undefined extends AppParamList[K]
+  ? true
+  : false;
+
+/**
  * A forwarded navigation target: navigateParams is typed by the destination
  * route, so routing through the PIN gate keeps the destination's contract.
+ *
+ * navigateParams is required exactly where the destination requires params
+ * (WEB_BROWSER, VOTERS, CHAT_THREAD, ASSET_DETAILS, PROFILE_EDIT), so a
+ * paramless forward to one of those is a type error rather than a runtime
+ * screen with nothing to render.
  */
 export type ForwardedNavigation = {
-  [K in RouteName]: { navigateTo: K; navigateParams?: AppParamList[K]; navigateKey?: string };
+  [K in RouteName]: ParamsOptional<K> extends true
+    ? { navigateTo: K; navigateParams?: AppParamList[K]; navigateKey?: string }
+    : { navigateTo: K; navigateParams: AppParamList[K]; navigateKey?: string };
 }[RouteName];
 
 /** Params the PinCode screen forwards to its container as pinCodeParams. */

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -30,10 +30,18 @@ export type ParamsOptional<K extends RouteName> = K extends typeof ROUTES.SCREEN
  * params is required exactly when the destination requires them, so a paramless call to
  * WEB_BROWSER and friends is a type error. A plain `params?: AppParamList[K]` would not do
  * this: the `?` makes the argument optional for every route regardless of its contract.
+ *
+ * The outer `K extends RouteName` is what makes this distribute. Without it, a caller whose
+ * route is typed as the whole RouteName union collapses ParamsOptional<K> to boolean, which
+ * fails `extends true` and yields [RouteName, AppParamList[RouteName]] where the params union
+ * already includes undefined, so the required-params routes stop being checked. Distributing
+ * produces one tuple per route instead, and a union-typed route matches none of them.
  */
-export type NavigateArgs<K extends RouteName> = ParamsOptional<K> extends true
-  ? [route: K, params?: AppParamList[K]]
-  : [route: K, params: AppParamList[K]];
+export type NavigateArgs<K extends RouteName> = K extends RouteName
+  ? ParamsOptional<K> extends true
+    ? [route: K, params?: AppParamList[K]]
+    : [route: K, params: AppParamList[K]]
+  : never;
 
 /**
  * A forwarded navigation target: navigateParams is typed by the destination

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -25,6 +25,17 @@ export type ParamsOptional<K extends RouteName> = K extends typeof ROUTES.SCREEN
   : false;
 
 /**
+ * Argument list for a helper that takes a route and its params as two arguments.
+ *
+ * params is required exactly when the destination requires them, so a paramless call to
+ * WEB_BROWSER and friends is a type error. A plain `params?: AppParamList[K]` would not do
+ * this: the `?` makes the argument optional for every route regardless of its contract.
+ */
+export type NavigateArgs<K extends RouteName> = ParamsOptional<K> extends true
+  ? [route: K, params?: AppParamList[K]]
+  : [route: K, params: AppParamList[K]];
+
+/**
  * A forwarded navigation target: navigateParams is typed by the destination
  * route, so routing through the PIN gate keeps the destination's contract.
  *

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -28,7 +28,8 @@ import {
   setIsDarkTheme,
   recordAppSession,
 } from '../../../redux/actions/applicationActions';
-import RootNavigation from '../../../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
+import { PinCodeParams } from '../../../navigation/types';
 import ROUTES from '../../../constants/routeNames';
 import { selectCurrentAccount } from '../../../redux/selectors';
 
@@ -278,9 +279,6 @@ export const useInitApplication = () => {
 
         case 'transfer':
           routeName = ROUTES.TABBAR.WALLET;
-          params = {
-            activePage: 2,
-          };
           break;
 
         case 'inactive':
@@ -308,12 +306,15 @@ export const useInitApplication = () => {
         markNotificationsReadMutation.mutate(activity_id);
       }
 
-      // Only an empty *string* param (e.g. missing author/permlink) should block
-      // navigation. lodash isEmpty(2) is true for numbers, which previously stopped
-      // transfer notifications (params { activePage: 2 }) from opening the wallet.
+      // Only an empty *string* param (e.g. missing author/permlink) should block navigation.
+      // This replaced a lodash isEmpty check, which reported numeric params as empty and so
+      // blocked any notification that carried one.
       const _hasEmptyStringParam = some(params, (v) => typeof v === 'string' && v.trim() === '');
       if (routeName && !_hasEmptyStringParam) {
         if (isPinCodeOpen) {
+          // routeName and params are set together per notification type in the switch above,
+          // but they are separate locals by the time they get here, so the pairing cannot be
+          // checked. The casts are the seam: everything either side of them is typed.
           RootNavigation.navigate({
             name: ROUTES.SCREENS.PINCODE,
             params: {
@@ -321,14 +322,14 @@ export const useInitApplication = () => {
               navigateParams: params,
               navigateKey: key,
               hideCloseButton: true,
-            },
+            } as PinCodeParams,
           });
         } else {
           RootNavigation.navigate({
             name: routeName,
             params,
             key,
-          });
+          } as NavigateOptions);
         }
       }
     }

--- a/src/screens/assetDetails/children/children.styles.ts
+++ b/src/screens/assetDetails/children/children.styles.ts
@@ -171,6 +171,5 @@ export default EStyleSheet.create({
   },
   closeIcon: {
     color: '$iconColor',
-    // paddingRight: 0
   },
 });

--- a/src/screens/assetDetails/children/recurrentTransfersModal.tsx
+++ b/src/screens/assetDetails/children/recurrentTransfersModal.tsx
@@ -15,6 +15,9 @@ import { walletQueries } from '../../../providers/queries';
 import { IconButton } from '../../../components/iconButton';
 import { selectIsDarkTheme } from '../../../redux/selectors';
 
+// Brings the 30x30 IconButton up to the 44x44 minimum touch target without changing its layout.
+const CLOSE_HIT_SLOP = { top: 7, bottom: 7, left: 7, right: 7 };
+
 interface RecurrentTransfersModalProps {
   assetId: string;
 }
@@ -76,7 +79,9 @@ export const RecurrentTransfersModal = forwardRef(
       return (
         <IconButton
           size={24}
-          style={{ paddingRight: 0 }}
+          // The button itself is a fixed 30x30, below the 44pt guideline, and it sits in a row
+          // of transfers where a mis-tap cancels the wrong schedule.
+          hitSlop={CLOSE_HIT_SLOP}
           iconStyle={styles.closeIcon}
           name="close"
           iconType="MaterialCommunityIcons"

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -10,7 +10,8 @@ import { CoinSummary, ActivitiesList, RecurrentTransfersModal } from '../childre
 import styles from './screen.styles';
 import { CoinActivity } from '../../../redux/reducers/walletReducer';
 import { useAppSelector } from '../../../hooks';
-import RootNavigation from '../../../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
+import { PinCodeParams, RouteName } from '../../../navigation/types';
 import ROUTES from '../../../constants/routeNames';
 import { selectCurrentAccount, selectIsPinCodeOpen } from '../../../redux/selectors';
 import { DelegationsModal, MODES } from '../children/delegationsModal';
@@ -141,8 +142,8 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
   };
 
   const _onActionPress = (transferType: string, baseActivity: CoinActivity | null = null) => {
-    let navigateTo: string = ROUTES.SCREENS.TRANSFER;
-    let navigateParams = {};
+    let navigateTo: RouteName = ROUTES.SCREENS.TRANSFER;
+    let navigateParams: any = {};
     let baseBalance = asset.liquid ?? 0;
     let fundType = assetSymbol;
 
@@ -219,18 +220,20 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
     }
 
     if (isPinCodeOpen) {
+      // navigateTo and navigateParams are built together in the switches above but are separate
+      // locals here, so the pairing cannot be checked at this point.
       RootNavigation.navigate({
         name: ROUTES.SCREENS.PINCODE,
         params: {
           navigateTo,
           navigateParams,
-        },
+        } as PinCodeParams,
       });
     } else {
       RootNavigation.navigate({
         name: navigateTo,
         params: navigateParams,
-      });
+      } as NavigateOptions);
     }
   };
 

--- a/src/screens/perks/children/spendOptions.tsx
+++ b/src/screens/perks/children/spendOptions.tsx
@@ -4,11 +4,12 @@ import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 
 import { Icon } from '../../../components';
-import RootNavigation from '../../../navigation/rootNavigation';
+import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
+import { AppParamList, RouteName } from '../../../navigation/types';
 import ROUTES from '../../../constants/routeNames';
 import styles from '../styles/perksStyles';
 
-const OPTIONS: { id: string; icon: string; route: string; params?: any }[] = [
+const OPTIONS: { id: string; icon: string; route: RouteName; params?: any }[] = [
   { id: 'spin', icon: 'gift-outline', route: ROUTES.SCREENS.SPIN_GAME },
   {
     id: 'boost_plus',
@@ -34,8 +35,9 @@ const OPTIONS: { id: string; icon: string; route: string; params?: any }[] = [
 const SpendOptions = () => {
   const intl = useIntl();
 
-  const _navigate = (route: string, params?: any) => {
-    RootNavigation.navigate({ name: route, params });
+  const _navigate = <K extends RouteName>(route: K, params?: AppParamList[K]) => {
+    // Correlated by the generic at the call site; TS cannot re-derive that pairing here.
+    RootNavigation.navigate({ name: route, params } as NavigateOptions);
   };
 
   return (

--- a/src/screens/perks/children/spendOptions.tsx
+++ b/src/screens/perks/children/spendOptions.tsx
@@ -5,40 +5,37 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 
 import { Icon } from '../../../components';
 import RootNavigation, { NavigateOptions } from '../../../navigation/rootNavigation';
-import { AppParamList, RouteName } from '../../../navigation/types';
 import ROUTES from '../../../constants/routeNames';
 import styles from '../styles/perksStyles';
 
-const OPTIONS: { id: string; icon: string; route: RouteName; params?: any }[] = [
-  { id: 'spin', icon: 'gift-outline', route: ROUTES.SCREENS.SPIN_GAME },
+// `nav` is a whole NavigateOptions rather than a route plus loose params, so each entry's
+// params are checked against its own destination right here in the literal.
+const OPTIONS: { id: string; icon: string; nav: NavigateOptions }[] = [
+  { id: 'spin', icon: 'gift-outline', nav: { name: ROUTES.SCREENS.SPIN_GAME } },
   {
     id: 'boost_plus',
     icon: 'fire',
-    route: ROUTES.SCREENS.REDEEM,
-    params: { redeemType: 'boost_plus' },
+    nav: { name: ROUTES.SCREENS.REDEEM, params: { redeemType: 'boost_plus' } },
   },
   {
     id: 'rc_topup',
     icon: 'lightning-bolt',
-    route: ROUTES.SCREENS.REDEEM,
-    params: { redeemType: 'rc_topup' },
+    nav: { name: ROUTES.SCREENS.REDEEM, params: { redeemType: 'rc_topup' } },
   },
   {
     id: 'promote',
     icon: 'bullhorn-outline',
-    route: ROUTES.SCREENS.REDEEM,
-    params: { redeemType: 'promote' },
+    nav: { name: ROUTES.SCREENS.REDEEM, params: { redeemType: 'promote' } },
   },
-  { id: 'account_boost', icon: 'rocket-launch-outline', route: ROUTES.SCREENS.ACCOUNT_BOOST },
+  {
+    id: 'account_boost',
+    icon: 'rocket-launch-outline',
+    nav: { name: ROUTES.SCREENS.ACCOUNT_BOOST },
+  },
 ];
 
 const SpendOptions = () => {
   const intl = useIntl();
-
-  const _navigate = <K extends RouteName>(route: K, params?: AppParamList[K]) => {
-    // Correlated by the generic at the call site; TS cannot re-derive that pairing here.
-    RootNavigation.navigate({ name: route, params } as NavigateOptions);
-  };
 
   return (
     <View style={styles.card}>
@@ -47,7 +44,7 @@ const SpendOptions = () => {
         <TouchableOpacity
           key={opt.id}
           style={[styles.spendRow, index === OPTIONS.length - 1 && { borderBottomWidth: 0 }]}
-          onPress={() => _navigate(opt.route, opt.params)}
+          onPress={() => RootNavigation.navigate(opt.nav)}
         >
           <View style={styles.iconWrap}>
             <Icon

--- a/src/screens/post/screen/postScreen.tsx
+++ b/src/screens/post/screen/postScreen.tsx
@@ -156,6 +156,10 @@ const PostScreen = ({ route }: any) => {
         ref={postOptionsModalRef}
         isWave={isWavePost}
         isVisibleTranslateModal={isSubPost}
+        // This modal is only opened from the header dropdown, which always acts on the post
+        // this screen *is*, so deleting it has to pop. Comments rendered below come with their
+        // own modal and their own onDelete.
+        popScreenOnDelete={true}
       />
     </SafeAreaView>
   );

--- a/src/utils/deepLinkParser.ts
+++ b/src/utils/deepLinkParser.ts
@@ -3,12 +3,14 @@ import { getQueryClient, getAccountFullQueryOptions } from '@ecency/sdk';
 import postUrlParser, { parseWavesUrl } from './postUrlParser';
 import parseAuthUrl, { AUTH_MODES } from './parseAuthUrl';
 import ROUTES from '../constants/routeNames';
+import { RouteName } from '../navigation/types';
 import parsePurchaseUrl from './parsePurchaseUrl';
 
 // name can be undefined on fall-through: useLinkProcessor only navigates
-// natively when name, params and key are all set.
+// natively when name, params and key are all set. Typing it as RouteName rather than string
+// means a route that does not exist fails here, at the branch that produced it.
 export interface DeepLinkRoute {
-  name?: string;
+  name?: RouteName;
   params?: any;
   key?: string;
 }
@@ -18,7 +20,7 @@ export const deepLinkParser = async (
 ): Promise<DeepLinkRoute | undefined> => {
   if (!url || url.indexOf('ShareMedia://') >= 0) return;
 
-  let routeName: string | undefined;
+  let routeName: RouteName | undefined;
   let params: any;
   let profile;
   let keey: string | undefined;

--- a/src/utils/parseAsset.test.ts
+++ b/src/utils/parseAsset.test.ts
@@ -1,0 +1,26 @@
+import parseAsset from './parseAsset';
+
+describe('parseAsset', () => {
+  it('parses the symbol, which used to come back undefined off the global Symbol', () => {
+    expect(parseAsset('1.000 HIVE')).toEqual({ amount: 1, symbol: 'HIVE' });
+    expect(parseAsset('2.500 HBD')).toEqual({ amount: 2.5, symbol: 'HBD' });
+    expect(parseAsset('1234.567890 VESTS')).toEqual({ amount: 1234.56789, symbol: 'VESTS' });
+  });
+
+  it('returns an empty symbol for a ticker outside the Hive assets, such as Hive Engine', () => {
+    expect(parseAsset('10.000 LEO')).toEqual({ amount: 10, symbol: '' });
+  });
+
+  it('tolerates a missing value instead of throwing, which the SDK version does not', () => {
+    // postParser calls this on max_accepted_payout and the payout fields, which the search
+    // API omits. The SDK version reads `sval.amount` on anything non-string and throws.
+    expect(parseAsset(undefined as any)).toEqual({ amount: 0, symbol: '' });
+    expect(parseAsset(null as any)).toEqual({ amount: 0, symbol: '' });
+    expect(parseAsset(42 as any)).toEqual({ amount: 0, symbol: '' });
+  });
+
+  it('keeps the existing amount behaviour for unparseable input', () => {
+    expect(parseAsset('').amount).toBeNaN();
+    expect(parseAsset('abc HIVE').amount).toBeNaN();
+  });
+});

--- a/src/utils/parseAsset.ts
+++ b/src/utils/parseAsset.ts
@@ -1,8 +1,21 @@
-interface Asset {
+import { parseAsset as sdkParseAsset, Symbol as AssetSymbol } from '@ecency/sdk';
+
+export interface Asset {
   amount: number;
-  symbol: symbol | string;
+  symbol: AssetSymbol | '';
 }
 
+/**
+ * Thin wrapper over the SDK's parseAsset that tolerates a missing value.
+ *
+ * The SDK version assumes anything non-string is an SMTAsset and reads `sval.amount`, so it throws
+ * on undefined. postParser calls this on `max_accepted_payout` and the payout fields, which the
+ * search API omits, so the guard below is load-bearing: it cannot be dropped in favour of
+ * re-exporting the SDK function directly.
+ *
+ * This previously indexed the *global* `Symbol` constructor, so `symbol` was undefined for every
+ * input. Callers only ever read `.amount`, which is why it went unnoticed.
+ */
 const parseAsset = (strVal: string): Asset => {
   if (typeof strVal !== 'string') {
     return {
@@ -10,10 +23,13 @@ const parseAsset = (strVal: string): Asset => {
       symbol: '',
     };
   }
-  const sp = strVal.split(' ');
+
+  const { amount, symbol } = sdkParseAsset(strVal);
+
+  // Hive Engine tickers are not in the SDK's Symbol enum, so they parse to undefined.
   return {
-    amount: parseFloat(sp[0]),
-    symbol: (Symbol as any)[sp[1]],
+    amount,
+    symbol: symbol ?? '',
   };
 };
 


### PR DESCRIPTION
Bundles four hardening issues filed after the recent wallet and sheet work, plus the review leftovers from #3461. One commit per issue.

### #3488 parseAsset returned undefined for every symbol
`src/utils/parseAsset.ts` indexed the global `Symbol` constructor, so `Symbol['HIVE']` was `undefined` for all input. Latent, since all 11 call sites read `.amount` only.

The string case now delegates to the SDK's `parseAsset`, which owns the enum. The local non-string guard stays: the SDK version treats anything non-string as an SMTAsset and reads `sval.amount`, and `postParser.tsx:142` calls this on `max_accepted_payout`, which the search API omits (the `_isNumericPayoutOnly` branch right below it exists for exactly that shape). Re-exporting the SDK function directly would throw there. Adds the first test coverage for the helper.

### #3476 six sheets documented the wrong mount model
`CLAUDE.md` was corrected in #3467; the comments were not. Sheets mount on show and unmount on hide.

Each file's unmount cleanups and reset-on-payload logic were read against the correct model. Five are comment-only. `composeTranslateModal` needed a code change: `closedRef`, which cancels the in-flight translation chain, was set from `onClose` alone, so a sheet leaving by any other route left the chain paging the translation service. It is now set from unmount as well.

### #3463 recurrentTransfersModal close button
`style={{ paddingRight: 0 }}` cancelled nothing (the typed IconButton's base style is a fixed 30x30 with no padding), and the commented-out `paddingRight` in `closeIcon` was stale for the same reason. Both removed.

30x30 is below the 44pt guideline and the button sits in a row where a mis-tap cancels the wrong schedule, so `IconButton` gains an optional `hitSlop` pass-through, opted into at this one call site. Unset everywhere else, so no other icon button changes.

### #3462 navigation contract bypass gaps
`RootNavigation.navigate` took `any` and cast the ref, so all 51 callers bypassed `AppParamList`. Now typed against it. `ForwardedNavigation` left `navigateParams` optional for every route; it is now required exactly when the destination's params exclude `undefined`.

Deriving that optionality makes `PINCODE` circular, since `PinCodeParams` embeds `ForwardedNavigation`, so `ParamsOptional` answers `PINCODE` without probing its params.

Typing it surfaced four dead or wrong params, none read by their destination:

| Site | Param |
|---|---|
| `commentBodyView` | a navigation key passed inside `params`; `postBodyView` does the same navigation without it |
| `useLinkProcessor` | `accessToken` to PINCODE and DRAWER.MAIN |
| `useInitApplication` | `activePage` to the wallet tab |
| `postHeaderDescription` | fell through to `navigate({})` when `content` matched none of its four branches |

`deepLinkParser`'s route name is now `RouteName` rather than `string`, so a nonexistent route fails at the branch that built it. Where a route name and its params are separate locals by the time they reach dispatch, the pairing cannot be checked and the cast is commented as the seam.

### #3409 options sheet delete now fails safe
`_deletePost` called `navigation.goBack()` unless the consumer passed `onDelete`, wrong for any consumer owning a surrounding list, and hit three times (waves, the comment surfaces in #3405/#3406, the feed list in #3407). Inverted into an explicit `popScreenOnDelete` opt-in.

`postScreen` is the only consumer needing it: its modal is opened solely from the header dropdown, which always acts on the post the screen *is*, and comments below carry their own modal and `onDelete`. Note the issue's table lists `editorScreen` as a sixth consumer, but `src/screens/editor/children/postOptionsModal.tsx` is an unrelated component (beneficiaries, scheduling, thumbnails), so there are five.

### Verification
`tsc --noEmit` clean against the empty baseline, eslint 0 errors (one fewer warning than `development`), 821 unit tests pass. No device pass, and none of this is on a screen the wallet device pass covers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the touch target for the recurrent transfer unsubscribe button.
  * Added control over whether deleting a post returns to the previous screen.
  * Post deletion from the post screen now returns to the previous screen.

* **Bug Fixes**
  * Improved notification and deep-link navigation reliability.
  * Prevented unsupported tags from triggering navigation.
  * Stopped in-progress translations when their modal closes.
  * Improved asset parsing for unsupported or invalid values.

* **Tests**
  * Added coverage for asset parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->