### PR TITLE
chore: bump @ecency/sdk to 2.3.83 and drop the wallet history initialData guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.82",
+    "@ecency/sdk": "^2.3.83",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -396,13 +396,10 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
 
   const chainQuery = useInfiniteQuery({
     ...chainQueryOptions,
-    // Guard, not a workaround. These options used to seed
-    // `initialData: { pages: [], pageParams: [] }` for the web's server-prefetched
-    // pages; against this client's staleTime of 60s that empty seed reads as fresh
-    // data and suppresses the very first fetch, so the history renders empty and
-    // nothing reports an error. @ecency/sdk 2.3.80 dropped it, and no SDK test pins
-    // its absence, so keep this until one does.
-    initialData: undefined,
+    // No initialData override needed: these options used to seed an empty page set
+    // that read as fresh against this client's 60s staleTime and suppressed the very
+    // first fetch. @ecency/sdk 2.3.80 dropped the seed and 2.3.83 pins its absence
+    // with a spec, so the contract is enforced upstream.
     enabled: !!username && isHive,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.82":
-  version "2.3.82"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.82.tgz#74e9cfcb278de2f810446262c3516db539c8340d"
-  integrity sha512-8kYahuQ8CcCDimKsze22GXCziyv4fQDAyshj8QYQEySVFiMj0sHU06F2g0IZ+tg+pufpcImp55JQae+a65naYQ==
+"@ecency/sdk@^2.3.83":
+  version "2.3.83"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.83.tgz#c61382f9ff8a16eb194811eee0e157b2c9502674"
+  integrity sha512-DXzv++9jHGaSKGbcIxqdTZpfCSjUSEFkQxime0Fx+qk5l+6X4kdyMdBpWm/hUiSaDkZAPv7rlbYluiRYtN0vZg==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Raises the @ecency/sdk floor to ^2.3.83 (published from ecency/vision-web#1427) and removes the `initialData: undefined` override on the wallet history chain query. The guard's own comment gated its removal on an SDK spec pinning the absence of the empty seed; 2.3.83 ships that spec for both the notifications options and the HIVE/HBD/HP asset transaction options, so the contract is enforced upstream now.

Verified: typecheck clean against the empty baseline, lint 0 errors, 821 jest tests pass.

Closes #3492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior for chain activity history by relying on standard query defaults.
* **Chores**
  * Updated the Ecency SDK to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->