### PR TITLE
feat(rc): warn before publishing a post the account cannot afford

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.83",
+    "@ecency/sdk": "^2.3.85",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/rcPrecheckBanner/index.ts
+++ b/src/components/rcPrecheckBanner/index.ts
@@ -1,0 +1,4 @@
+import RcPrecheckBanner from './rcPrecheckBanner';
+
+export { RcPrecheckBanner };
+export default RcPrecheckBanner;

--- a/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
+++ b/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
+import { useQuery } from '@tanstack/react-query';
+import { getSupportSettingsQueryOptions } from '@ecency/sdk';
 import type { RcPrecheckPayload } from '@ecency/sdk';
 
 import { setRcOffer } from '../../redux/actions/uiAction';
@@ -25,6 +27,7 @@ interface Props {
   pollDraft?: any;
   rewardType?: string;
   beneficiaries?: any[];
+  hasExplicitBeneficiaries?: boolean;
 }
 
 /**
@@ -58,6 +61,7 @@ const RcPrecheckBanner = ({
   pollDraft,
   rewardType,
   beneficiaries,
+  hasExplicitBeneficiaries,
 }: Props) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
@@ -66,6 +70,17 @@ const RcPrecheckBanner = ({
   const body = fields?.body ?? '';
   const title = fields?.title ?? '';
   const tags = fields?.tags;
+
+  // Cache read only. The submit path fetches this with a decrypted token, which
+  // is far too heavy to repeat while someone types, so the support row is
+  // priced whenever the settings screen or beneficiary modal has already warmed
+  // the shared cache entry, and skipped otherwise. Skipping can only make the
+  // estimate lower by one beneficiary row, never raise a false warning.
+  const { data: supportSettings } = useQuery({
+    ...getSupportSettingsQueryOptions(username, undefined),
+    enabled: false,
+  });
+  const supportPercent = supportSettings?.beneficiary_percent ?? 0;
 
   // Regenerating this on every rebuild is churn: it is time-derived, so only
   // its length reaches the estimate, and the millisecond component can change
@@ -94,6 +109,8 @@ const RcPrecheckBanner = ({
         pollDraft,
         rewardType,
         beneficiaries,
+        hasExplicitBeneficiaries,
+        supportPercent,
       })
         .then((next) => {
           if (!cancelled) {
@@ -127,6 +144,8 @@ const RcPrecheckBanner = ({
     JSON.stringify(videoThumbUrls),
     thumbUrl,
     rewardType,
+    hasExplicitBeneficiaries,
+    supportPercent,
     post?.author,
     post?.permlink,
     post?.markdownBody,

--- a/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
+++ b/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useIntl } from 'react-intl';
+import type { RcPrecheckPayload } from '@ecency/sdk';
+
+import { setRcOffer } from '../../redux/actions/uiAction';
+import { useAppDispatch } from '../../hooks';
+import { useRcPrecheck } from '../../hooks/useRcPrecheck';
+import { generateUniquePermlink } from '../../utils/editor';
+import { buildEditorRcPayload } from '../../utils/rcPayload';
+import styles from './rcPrecheckBannerStyles';
+
+interface Props {
+  /** The account that will sign, or undefined when logged out. */
+  username?: string;
+  /** The editor's live draft: title, body, tags, aiTools. */
+  fields: any;
+  /** The parent post, when this editor is composing a reply. */
+  post?: any;
+  isReply?: boolean;
+}
+
+/**
+ * Costing the draft is not free: it parses the body for images and links, so it
+ * runs on a pause in typing rather than on every keystroke.
+ */
+const BUILD_DEBOUNCE_MS = 800;
+
+/**
+ * Warns, while the draft is still being written, that the account cannot afford
+ * to broadcast it.
+ *
+ * Before this the first anyone heard of a shortfall was the chain rejecting a
+ * post they had already finished, and for a large enough post waiting does not
+ * help either: the cost can exceed the account's maximum RC rather than just
+ * its current balance.
+ *
+ * Non-blocking by design. The estimate carries a safety buffer and the pool
+ * moves between the estimate and the broadcast, so this advises and never
+ * prevents. Tapping it opens the same offer sheet a failed broadcast raises, so
+ * there is one place that sells a top-up or a boost.
+ */
+const RcPrecheckBanner = ({ username, fields, post, isReply }: Props) => {
+  const intl = useIntl();
+  const dispatch = useAppDispatch();
+  const [payload, setPayload] = useState<RcPrecheckPayload | undefined>();
+
+  const body = fields?.body ?? '';
+  const title = fields?.title ?? '';
+  const tags = fields?.tags;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const timer = setTimeout(() => {
+      buildEditorRcPayload({
+        username: username!,
+        fields,
+        post,
+        isReply,
+        // Time-derived at broadcast, so only its length feeds the estimate.
+        replyPermlink: isReply
+          ? generateUniquePermlink(`re-${String(post?.author ?? '').replace(/\./g, '')}`)
+          : undefined,
+      })
+        .then((next) => {
+          if (!cancelled) {
+            setPayload(next);
+          }
+        })
+        .catch(() => {
+          // An estimate is a courtesy. If the draft cannot be costed, say
+          // nothing rather than guessing or interrupting the writer.
+          if (!cancelled) {
+            setPayload(undefined);
+          }
+        });
+    }, BUILD_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [username, title, body, JSON.stringify(tags), post?.author, post?.permlink, isReply]);
+
+  useEffect(() => {
+    if (!username) {
+      setPayload(undefined);
+    }
+  }, [username]);
+
+  const { ready, willLikelyFail } = useRcPrecheck(username, payload);
+
+  if (!username || !ready || !willLikelyFail) {
+    return null;
+  }
+
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      onPress={() => dispatch(setRcOffer(true))}
+      style={styles.container}
+    >
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>{intl.formatMessage({ id: 'alert.rc_precheck_title' })}</Text>
+        <Text style={styles.body}>{intl.formatMessage({ id: 'alert.rc_precheck_body' })}</Text>
+      </View>
+      <Text style={styles.action}>{intl.formatMessage({ id: 'alert.rc_down_topup' })}</Text>
+    </TouchableOpacity>
+  );
+};
+
+export default RcPrecheckBanner;

--- a/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
+++ b/src/components/rcPrecheckBanner/rcPrecheckBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import type { RcPrecheckPayload } from '@ecency/sdk';
@@ -15,9 +15,16 @@ interface Props {
   username?: string;
   /** The editor's live draft: title, body, tags, aiTools. */
   fields: any;
-  /** The parent post, when this editor is composing a reply. */
+  /** The parent post when replying, or the post itself when editing. */
   post?: any;
   isReply?: boolean;
+  isEdit?: boolean;
+  /** The rest of what the submit path puts in the broadcast. */
+  thumbUrl?: string;
+  videoThumbUrls?: string[];
+  pollDraft?: any;
+  rewardType?: string;
+  beneficiaries?: any[];
 }
 
 /**
@@ -40,7 +47,18 @@ const BUILD_DEBOUNCE_MS = 800;
  * prevents. Tapping it opens the same offer sheet a failed broadcast raises, so
  * there is one place that sells a top-up or a boost.
  */
-const RcPrecheckBanner = ({ username, fields, post, isReply }: Props) => {
+const RcPrecheckBanner = ({
+  username,
+  fields,
+  post,
+  isReply,
+  isEdit,
+  thumbUrl,
+  videoThumbUrls,
+  pollDraft,
+  rewardType,
+  beneficiaries,
+}: Props) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const [payload, setPayload] = useState<RcPrecheckPayload | undefined>();
@@ -48,6 +66,17 @@ const RcPrecheckBanner = ({ username, fields, post, isReply }: Props) => {
   const body = fields?.body ?? '';
   const title = fields?.title ?? '';
   const tags = fields?.tags;
+
+  // Regenerating this on every rebuild is churn: it is time-derived, so only
+  // its length reaches the estimate, and the millisecond component can change
+  // that length at digit boundaries.
+  const replyPermlink = useMemo(
+    () =>
+      isReply
+        ? generateUniquePermlink(`re-${String(post?.author ?? '').replace(/\./g, '')}`)
+        : undefined,
+    [isReply, post?.author],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -58,10 +87,13 @@ const RcPrecheckBanner = ({ username, fields, post, isReply }: Props) => {
         fields,
         post,
         isReply,
-        // Time-derived at broadcast, so only its length feeds the estimate.
-        replyPermlink: isReply
-          ? generateUniquePermlink(`re-${String(post?.author ?? '').replace(/\./g, '')}`)
-          : undefined,
+        isEdit,
+        replyPermlink,
+        thumbUrl,
+        videoThumbUrls,
+        pollDraft,
+        rewardType,
+        beneficiaries,
       })
         .then((next) => {
           if (!cancelled) {
@@ -81,8 +113,27 @@ const RcPrecheckBanner = ({ username, fields, post, isReply }: Props) => {
       cancelled = true;
       clearTimeout(timer);
     };
+    // Serialized rather than listed by reference: these arrive as fresh objects
+    // on every editor render, which would restart the debounce forever.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [username, title, body, JSON.stringify(tags), post?.author, post?.permlink, isReply]);
+  }, [
+    username,
+    title,
+    body,
+    JSON.stringify(tags),
+    JSON.stringify(fields?.aiTools),
+    JSON.stringify(beneficiaries),
+    JSON.stringify(pollDraft),
+    JSON.stringify(videoThumbUrls),
+    thumbUrl,
+    rewardType,
+    post?.author,
+    post?.permlink,
+    post?.markdownBody,
+    isReply,
+    isEdit,
+    replyPermlink,
+  ]);
 
   useEffect(() => {
     if (!username) {

--- a/src/components/rcPrecheckBanner/rcPrecheckBannerStyles.ts
+++ b/src/components/rcPrecheckBanner/rcPrecheckBannerStyles.ts
@@ -1,0 +1,33 @@
+import EStyleSheet from 'react-native-extended-stylesheet';
+
+export default EStyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '$primaryLightBackground',
+    borderLeftWidth: 3,
+    borderLeftColor: '$primaryRed',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  textContainer: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: 'bold',
+    color: '$primaryBlack',
+  },
+  body: {
+    fontSize: 12,
+    color: '$primaryDarkGray',
+    marginTop: 2,
+  },
+  action: {
+    fontSize: 13,
+    fontWeight: 'bold',
+    color: '$primaryBlue',
+  },
+});

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -870,6 +870,8 @@
     "connection_success": "Successfully connected!",
     "rc_down": "Not enough resource credits to perform an action! \n\nBoost your account to continue enjoy the experience. Do you want to boost your account, now?",
     "rc_down_title": "Not enough Resource Credits",
+    "rc_precheck_title": "This post may be too large to publish",
+    "rc_precheck_body": "Your resource credits look too low for a post this size.",
     "rc_down_body": "You do not have enough resource credits for this action.\n\nTop up now with Points to keep going, or boost your account for good.",
     "rc_down_topup": "Top up RC with Points",
     "rc_down_boost": "Boost account",

--- a/src/hooks/useRcPrecheck.ts
+++ b/src/hooks/useRcPrecheck.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  estimateRcPrecheck,
+  getAccountRcQueryOptions,
+  getRcResourceParamsQueryOptions,
+  getRcStatsQueryOptions,
+} from '@ecency/sdk';
+import type { RcPrecheckOperation, RcPrecheckPayload } from '@ecency/sdk';
+
+interface RcPrecheck {
+  /** All inputs were available, so the answer means something. */
+  ready: boolean;
+  /** The broadcast is likely to be rejected for insufficient RC. */
+  willLikelyFail: boolean;
+  /** RC the operation is estimated to cost. */
+  cost: number;
+  /** RC the account is short by, 0 when it is not short. */
+  deficit: number;
+}
+
+const NOT_READY: RcPrecheck = { ready: false, willLikelyFail: false, cost: 0, deficit: 0 };
+
+/**
+ * Whether the account can afford to broadcast what it is about to broadcast.
+ *
+ * RC cost is dominated by serialized transaction size, so a long post can cost
+ * many times an average comment. Without this the first anyone hears of a
+ * shortfall is the chain rejecting a post they already finished writing, and
+ * for a large enough post no amount of waiting helps: the cost can exceed the
+ * account's maximum RC, not merely its current balance.
+ *
+ * Pass the payload that will actually be broadcast. Without one the estimator
+ * prices a minimal operation of that type, which is a lower bound and so can
+ * miss a marginal case, but never warns about one that would have succeeded.
+ */
+export const useRcPrecheck = (
+  username: string | undefined,
+  payload?: RcPrecheckPayload,
+  operation: RcPrecheckOperation = 'comment_operation',
+): RcPrecheck => {
+  const { data: rcAccounts } = useQuery({
+    ...getAccountRcQueryOptions(username!),
+    enabled: !!username,
+  });
+  const { data: rcStats } = useQuery(getRcStatsQueryOptions());
+  const { data: rcParams } = useQuery(getRcResourceParamsQueryOptions());
+
+  if (!username) {
+    return NOT_READY;
+  }
+
+  const { ready, willLikelyFail, cost, deficit } = estimateRcPrecheck({
+    rcAccount: rcAccounts?.[0],
+    rcStats,
+    rcParams,
+    operation,
+    payload,
+  });
+
+  return { ready, willLikelyFail, cost, deficit };
+};

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -1994,6 +1994,7 @@ class EditorContainer extends Component<any, any> {
         postDescription={postDescription}
         handlePostDescriptionChange={this._handlePostDescriptionChange}
         getBeneficiaries={this._extractBeneficiaries}
+        getPollDraft={this._extractPollDraft}
         setIsUploading={this._setIsUploading}
       />
     );

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -618,6 +618,20 @@ class EditorContainer extends Component<any, any> {
     return beneficiariesMap[_draftId] || [];
   };
 
+  /**
+   * Whether the author set a beneficiary list for this draft. The submit path
+   * injects the Ecency support beneficiary only when they did not, so the RC
+   * estimate needs the same signal to price comment_options correctly.
+   */
+  _hasExplicitBeneficiaries = () => {
+    const { draftId } = this.state;
+    const { beneficiariesMap, currentAccount } = this.props;
+
+    const _draftId = draftId || DEFAULT_USER_DRAFT_ID + currentAccount.name;
+
+    return !!beneficiariesMap && Object.prototype.hasOwnProperty.call(beneficiariesMap, _draftId);
+  };
+
   _extractPollDraft = () => {
     const { draftId } = this.state;
     const { pollDraftsMap, currentAccount } = this.props;
@@ -1995,6 +2009,7 @@ class EditorContainer extends Component<any, any> {
         handlePostDescriptionChange={this._handlePostDescriptionChange}
         getBeneficiaries={this._extractBeneficiaries}
         getPollDraft={this._extractPollDraft}
+        hasExplicitBeneficiaries={this._hasExplicitBeneficiaries()}
         setIsUploading={this._setIsUploading}
       />
     );

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -511,6 +511,7 @@ class EditorScreen extends Component<any, any> {
       setIsUploading,
       getBeneficiaries,
       getPollDraft,
+      hasExplicitBeneficiaries,
     } = this.props;
 
     const rightButtonText = intl.formatMessage({
@@ -583,6 +584,7 @@ class EditorScreen extends Component<any, any> {
             pollDraft={getPollDraft && getPollDraft()}
             rewardType={rewardType}
             beneficiaries={getBeneficiaries && getBeneficiaries()}
+            hasExplicitBeneficiaries={hasExplicitBeneficiaries}
           />
           {!isReply && !isEdit && (
             <SelectCommunityAreaView

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -509,6 +509,8 @@ class EditorScreen extends Component<any, any> {
       rewardType,
       postDescription,
       setIsUploading,
+      getBeneficiaries,
+      getPollDraft,
     } = this.props;
 
     const rightButtonText = intl.formatMessage({
@@ -575,6 +577,12 @@ class EditorScreen extends Component<any, any> {
             fields={fields}
             post={post}
             isReply={isReply}
+            isEdit={isEdit}
+            thumbUrl={thumbUrl}
+            videoThumbUrls={collectVideoThumbUrls({ videoThumbs, body: fields?.body })}
+            pollDraft={getPollDraft && getPollDraft()}
+            rewardType={rewardType}
+            beneficiaries={getBeneficiaries && getBeneficiaries()}
           />
           {!isReply && !isEdit && (
             <SelectCommunityAreaView

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -28,6 +28,7 @@ import { getQueryClient } from '../../../providers/queries';
 
 // Styles
 import globalStyles from '../../../globalStyles';
+import RcPrecheckBanner from '../../../components/rcPrecheckBanner';
 import { isCommunity } from '../../../utils/communityValidation';
 
 import styles from './editorScreenStyles';
@@ -569,6 +570,12 @@ class EditorScreen extends Component<any, any> {
           isPreviewActive={isPreviewActive}
         > */}
         <Fragment>
+          <RcPrecheckBanner
+            username={currentAccount?.name}
+            fields={fields}
+            post={post}
+            isReply={isReply}
+          />
           {!isReply && !isEdit && (
             <SelectCommunityAreaView
               selectedAccount={selectedAccount}

--- a/src/utils/rcPayload.test.ts
+++ b/src/utils/rcPayload.test.ts
@@ -129,4 +129,152 @@ describe('buildEditorRcPayload', () => {
       expect(await buildEditorRcPayload({ username: '', fields: draft })).toBeUndefined();
     });
   });
+
+  // Regression: a post always broadcasts comment_options beside the comment,
+  // even on default reward settings. Omitting it understated every post.
+  describe('comment_options', () => {
+    it('carries options for a new post, on default settings', async () => {
+      const payload = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+
+      expect(payload?.options).toBeDefined();
+    });
+
+    it('carries the beneficiaries the post will actually send', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: draft,
+        beneficiaries: [{ account: 'ecency', weight: 500 }],
+      });
+
+      expect(payload?.options?.beneficiaries).toEqual([{ account: 'ecency', weight: 500 }]);
+    });
+
+    it('carries none for a reply, which sends no options', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { body: 'nice post' },
+        post: parent,
+        isReply: true,
+        replyPermlink: 're-alice-1',
+      });
+
+      expect(payload?.options).toBeUndefined();
+    });
+  });
+
+  // Regression: a poll goes into json_metadata and can be large, so a poll post
+  // could pass the precheck and still be rejected.
+  it('prices the poll the post will carry', async () => {
+    const withoutPoll = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+    const withPoll = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: draft,
+      pollDraft: {
+        title: 'Which proposal deserves funding the most this year?',
+        choices: Array.from({ length: 12 }, (_, i) => `A reasonably long choice number ${i}`),
+        interpretation: 'number_of_votes',
+        endTime: '2026-09-01T00:00:00.000Z',
+        voteChange: true,
+        hideVotes: false,
+        hideResults: false,
+        maxChoicesVoted: 1,
+        filters: { accountAge: 7 },
+      } as any,
+    });
+
+    expect(withPoll!.op.json_metadata.length).toBeGreaterThan(withoutPoll!.op.json_metadata.length);
+  });
+
+  it('prices the video thumbnails the post will carry', async () => {
+    const plain = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+    const withThumbs = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: draft,
+      videoThumbUrls: ['https://images.ecency.com/video-thumb-one.png'],
+    });
+
+    expect(withThumbs!.op.json_metadata).toContain('video-thumb-one');
+    expect(withThumbs!.op.json_metadata.length).toBeGreaterThan(plain!.op.json_metadata.length);
+  });
+
+  /**
+   * Regression: an edit keeps the post's identity and usually sends a diff, so
+   * pricing it as a brand new post invents warnings rather than missing them.
+   */
+  describe('edits', () => {
+    const editedPost = {
+      permlink: 'the-original-permlink',
+      parent_author: '',
+      parent_permlink: 'hive',
+      markdownBody: `${'The original body. '.repeat(500)}`,
+      json_metadata: { tags: ['hive'], app: 'ecency/3.0.0-mobile' },
+    };
+
+    it('keeps the original permlink and parent rather than deriving new ones', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: `${editedPost.markdownBody}One added sentence.` },
+        post: editedPost,
+        isEdit: true,
+      });
+
+      expect(payload?.op.permlink).toBe('the-original-permlink');
+      expect(payload?.op.parent_permlink).toBe('hive');
+      expect(payload?.op.parent_author).toBe('');
+    });
+
+    it('sends a diff, so a small change to a long post stays small', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: `${editedPost.markdownBody}One added sentence.` },
+        post: editedPost,
+        isEdit: true,
+      });
+
+      expect(payload!.op.body.length).toBeLessThan(editedPost.markdownBody.length / 2);
+    });
+
+    it('sends the whole body when a diff would not be smaller', async () => {
+      const replacement = 'Completely different text, nothing in common with what came before.';
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: replacement },
+        post: editedPost,
+        isEdit: true,
+      });
+
+      expect(payload?.op.body).toBe(replacement);
+    });
+
+    it('sends no comment_options, matching the update path', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: 'edited' },
+        post: editedPost,
+        isEdit: true,
+      });
+
+      expect(payload?.options).toBeUndefined();
+    });
+
+    it('keeps an AI disclosure the author is not touching', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: 'edited', aiTools: undefined },
+        post: {
+          ...editedPost,
+          json_metadata: { ...editedPost.json_metadata, ai_tools: { writing_edit: true } },
+        },
+        isEdit: true,
+      });
+
+      expect(JSON.parse(payload!.op.json_metadata).ai_tools).toEqual({ writing_edit: true });
+    });
+
+    it('returns nothing when there is no post to edit', async () => {
+      expect(
+        await buildEditorRcPayload({ username: 'spacecop', fields: draft, isEdit: true }),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/utils/rcPayload.test.ts
+++ b/src/utils/rcPayload.test.ts
@@ -1,0 +1,132 @@
+import { buildEditorRcPayload } from './rcPayload';
+
+jest.mock('react-native-version-number', () => ({ appVersion: '3.0.0' }));
+
+const draft = {
+  title: 'Who the DHF has actually paid',
+  body: 'A post about proposal payouts.\n\n![chart](https://images.ecency.com/chart.png)',
+  tags: ['hive', 'dhf'],
+};
+
+const parent = {
+  author: 'alice',
+  permlink: 'a-post',
+  json_metadata: { tags: ['photography'] },
+};
+
+describe('buildEditorRcPayload', () => {
+  it('builds the post operation the editor broadcasts', async () => {
+    const payload = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+
+    expect(payload?.kind).toBe('comment');
+    expect(payload?.op.author).toBe('spacecop');
+    expect(payload?.op.parent_author).toBe('');
+    // Category is the first tag.
+    expect(payload?.op.parent_permlink).toBe('hive');
+    expect(payload?.op.title).toBe(draft.title);
+    // Mobile broadcasts the body as written, with no transformation.
+    expect(payload?.op.body).toBe(draft.body);
+    // generatePermlink caps the slug at five words, which is what the editor
+    // sends, and only its length feeds the estimate.
+    expect(payload?.op.permlink).toBe('who-the-dhf-has-actually');
+  });
+
+  /**
+   * The reason the estimate is built from this rather than the raw draft: cost
+   * tracks serialized size, and the real metadata is much larger than tags
+   * alone.
+   */
+  it('carries the full metadata, not just tags', async () => {
+    const payload = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+    const meta = JSON.parse(payload!.op.json_metadata);
+
+    expect(meta.tags).toEqual(['hive', 'dhf']);
+    expect(meta.app).toContain('ecency');
+    expect(meta.format).toBe('markdown+html');
+    expect(meta.image).toContain('https://images.ecency.com/chart.png');
+    expect(payload!.op.json_metadata.length).toBeGreaterThan(
+      JSON.stringify({ tags: draft.tags }).length * 2,
+    );
+  });
+
+  it('grows the payload with the body, which is what moves the estimate', async () => {
+    const small = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+    const large = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: { ...draft, body: `${draft.body}\n\n${'x'.repeat(40000)}` },
+    });
+
+    expect(large!.op.body.length).toBeGreaterThan(small!.op.body.length + 39000);
+  });
+
+  it('falls back to the default tag when the draft has none, as the editor does', async () => {
+    const payload = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: { ...draft, tags: [] },
+    });
+
+    expect(payload?.op.parent_permlink).toBe('hive-125125');
+  });
+
+  it('drops blank tags the same way the editor does', async () => {
+    const payload = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: { ...draft, tags: [' ', '', 'hive'] as any },
+    });
+
+    expect(payload?.op.parent_permlink).toBe('hive');
+    expect(JSON.parse(payload!.op.json_metadata).tags).toEqual(['hive']);
+  });
+
+  it('folds in an AI disclosure when one is set', async () => {
+    const payload = await buildEditorRcPayload({
+      username: 'spacecop',
+      fields: { ...draft, aiTools: { writing_edit: true } },
+    });
+
+    expect(JSON.parse(payload!.op.json_metadata).ai_tools).toEqual({ writing_edit: true });
+  });
+
+  describe('replies', () => {
+    it('targets the parent and carries no title', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { body: 'nice post, thanks' },
+        post: parent,
+        isReply: true,
+        replyPermlink: 're-alice-20260814t120000000z',
+      });
+
+      expect(payload?.op.parent_author).toBe('alice');
+      expect(payload?.op.parent_permlink).toBe('a-post');
+      expect(payload?.op.title).toBe('');
+      expect(payload?.op.permlink).toBe('re-alice-20260814t120000000z');
+      // A reply inherits the parent's tags, which is what the editor sends.
+      expect(JSON.parse(payload!.op.json_metadata).tags).toEqual(['photography']);
+    });
+
+    it('falls back to the ecency tag when the parent has none', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { body: 'nice post' },
+        post: { author: 'alice', permlink: 'a-post', json_metadata: {} },
+        isReply: true,
+        replyPermlink: 're-alice-1',
+      });
+
+      expect(JSON.parse(payload!.op.json_metadata).tags).toEqual(['ecency']);
+    });
+  });
+
+  describe('when there is nothing to price', () => {
+    it('returns nothing without a body', async () => {
+      expect(
+        await buildEditorRcPayload({ username: 'spacecop', fields: { ...draft, body: '' } }),
+      ).toBeUndefined();
+    });
+
+    it('returns nothing without an account', async () => {
+      expect(await buildEditorRcPayload({ username: '', fields: draft })).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/rcPayload.test.ts
+++ b/src/utils/rcPayload.test.ts
@@ -277,4 +277,67 @@ describe('buildEditorRcPayload', () => {
       ).toBeUndefined();
     });
   });
+
+  // Regression: the stored list is not what gets broadcast. Submit adds a
+  // mandatory 3Speak row for an embedded video and the author's support row
+  // when they never set a list, and each lands in comment_options.
+  describe('submit-time beneficiaries', () => {
+    // The matcher looks for the embed URL specifically, not a watch link.
+    const THREESPEAK_BODY = `${draft.body}\n\n<iframe src="https://3speak.tv/embed?v=spacecop/abcdefghi"></iframe>`;
+
+    it('adds the 3Speak beneficiary an embed forces', async () => {
+      const plain = await buildEditorRcPayload({ username: 'spacecop', fields: draft });
+      const withVideo = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: { ...draft, body: THREESPEAK_BODY },
+      });
+
+      expect(plain?.options?.beneficiaries ?? []).toHaveLength(0);
+      expect(withVideo?.options?.beneficiaries?.length).toBeGreaterThan(0);
+    });
+
+    it('adds the support beneficiary when the author never set a list', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: draft,
+        hasExplicitBeneficiaries: false,
+        supportPercent: 5,
+      });
+
+      expect(payload?.options?.beneficiaries?.length).toBeGreaterThan(0);
+    });
+
+    it('leaves an author-set list alone, as the submit path does', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: draft,
+        beneficiaries: [{ account: 'alice', weight: 1000 }],
+        hasExplicitBeneficiaries: true,
+        supportPercent: 5,
+      });
+
+      expect(payload?.options?.beneficiaries).toEqual([{ account: 'alice', weight: 1000 }]);
+    });
+
+    it('adds nothing for the support account itself', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'ecency',
+        fields: draft,
+        hasExplicitBeneficiaries: false,
+        supportPercent: 5,
+      });
+
+      expect(payload?.options?.beneficiaries ?? []).toHaveLength(0);
+    });
+
+    it('adds nothing when the support percentage is unset or unknown', async () => {
+      const payload = await buildEditorRcPayload({
+        username: 'spacecop',
+        fields: draft,
+        hasExplicitBeneficiaries: false,
+      });
+
+      expect(payload?.options?.beneficiaries ?? []).toHaveLength(0);
+    });
+  });
 });

--- a/src/utils/rcPayload.ts
+++ b/src/utils/rcPayload.ts
@@ -1,7 +1,15 @@
 import type { RcPrecheckPayload } from '@ecency/sdk';
 
 import { PostTypes } from '../constants/postTypes';
-import { cleanAiTools, extractMetadata, generatePermlink, makeJsonMetadata } from './editor';
+import {
+  cleanAiTools,
+  createPatch,
+  extractMetadata,
+  generatePermlink,
+  makeJsonMetadata,
+  makeJsonMetadataForUpdate,
+  makeOptions,
+} from './editor';
 
 /**
  * The comment member of the payload union. Narrowed because this builder only
@@ -15,47 +23,80 @@ interface BuildArgs {
   username: string;
   /** The editor's live draft. */
   fields: { title?: string; body?: string; tags?: string[]; aiTools?: any };
-  /** The parent post, when composing a reply. */
+  /** The parent post when replying, or the post itself when editing. */
   post?: any;
   isReply?: boolean;
+  isEdit?: boolean;
   /**
    * The reply permlink is time-derived, so only its length matters here and a
-   * fresh one per keystroke would be noise. Injectable for tests.
+   * fresh one per rebuild would be churn. Injectable for tests.
    */
   replyPermlink?: string;
+  /** The rest of what the submit path feeds into the broadcast. */
+  thumbUrl?: string;
+  videoThumbUrls?: string[];
+  pollDraft?: any;
+  rewardType?: string;
+  beneficiaries?: any[];
 }
 
 /** Hive requires a parent permlink; the editor falls back to this tag when the draft has none. */
 const DEFAULT_TAG = 'hive-125125';
 
 /**
- * Assembles the comment operation the editor is about to broadcast, for pricing.
+ * Assembles the operation the editor is about to broadcast, for pricing.
  *
  * It has to be the real operation. RC cost tracks serialized transaction size,
- * so an estimate built from the raw draft with tags-only metadata understates a
- * post carrying a summary, images or links, and understating is the one
+ * so an estimate built from a reduced draft understates a post carrying a
+ * summary, images, a poll or beneficiaries, and understating is the one
  * direction that lets the chain reject a post we called affordable.
  *
- * Image ratios are deliberately not fetched: that would put requests on the
- * network every time typing pauses, and the few bytes they add can only make
- * the estimate lower, never a false alarm.
+ * Three shapes, because the editor broadcasts three:
+ *
+ * - a new post, which also sends comment_options for the reward split and any
+ *   beneficiaries, on default settings as much as custom ones;
+ * - a reply, which inherits the parent's tags and sends no options;
+ * - an edit, which keeps the original permlink and parent and sends a diff of
+ *   the body whenever that is smaller than the body, so pricing it as a new
+ *   post would invent warnings rather than miss them.
+ *
+ * Image ratios are the single deliberate omission: fetching them would put
+ * requests on the network every time typing pauses, and the few bytes they add
+ * can only make the estimate lower, never a false alarm.
  */
 export const buildEditorRcPayload = async ({
   username,
   fields,
   post,
   isReply,
+  isEdit,
   replyPermlink,
+  thumbUrl,
+  videoThumbUrls,
+  pollDraft,
+  rewardType,
+  beneficiaries,
 }: BuildArgs): Promise<CommentRcPayload | undefined> => {
   const body = fields?.body ?? '';
   if (!username || !body) {
     return undefined;
   }
 
+  const tags = (fields?.tags ?? []).filter((tag: any) => tag && tag !== ' ');
+
+  if (isEdit) {
+    return post
+      ? buildEditPayload({ username, fields, post, tags, thumbUrl, videoThumbUrls })
+      : undefined;
+  }
+
   const title = fields?.title ?? '';
   const meta = await extractMetadata({
     body,
+    thumbUrl,
+    videoThumbUrls,
     fetchRatios: false,
+    pollDraft,
     ...(isReply ? { postType: PostTypes.COMMENT } : {}),
   });
 
@@ -64,22 +105,95 @@ export const buildEditorRcPayload = async ({
     meta.ai_tools = aiTools;
   }
 
-  const tags = (fields?.tags ?? []).filter((tag: any) => tag && tag !== ' ');
+  const permlink = isReply ? replyPermlink ?? '' : generatePermlink(title);
   const jsonMetadata = makeJsonMetadata(
     meta,
     isReply ? post?.json_metadata?.tags || ['ecency'] : tags,
   );
 
+  // A post always broadcasts comment_options beside the comment, even on
+  // default reward settings, so the estimate has to account for it. A reply
+  // never does.
+  const options: any = isReply
+    ? undefined
+    : makeOptions({ author: username, permlink, operationType: rewardType, beneficiaries });
+
   return {
     kind: 'comment',
     op: {
       author: username,
-      permlink: isReply ? replyPermlink ?? '' : generatePermlink(title),
+      permlink,
       parent_author: isReply ? post?.author ?? '' : '',
       parent_permlink: isReply ? post?.permlink ?? '' : tags[0] || DEFAULT_TAG,
       title: isReply ? '' : title,
       body,
       json_metadata: JSON.stringify(jsonMetadata),
+    },
+    ...(options?.permlink
+      ? { options: { beneficiaries: options.extensions?.[0]?.[1]?.beneficiaries } }
+      : {}),
+  };
+};
+
+/**
+ * An edit keeps the post's identity and usually sends far less than the post
+ * did: the body goes out as a diff whenever that is smaller, and the metadata
+ * is merged over what the post already carries.
+ */
+const buildEditPayload = async ({
+  username,
+  fields,
+  post,
+  tags,
+  thumbUrl,
+  videoThumbUrls,
+}: {
+  username: string;
+  fields: BuildArgs['fields'];
+  post: any;
+  tags: string[];
+  thumbUrl?: string;
+  videoThumbUrls?: string[];
+}): Promise<CommentRcPayload> => {
+  const oldBody = post?.markdownBody ?? '';
+  const draftBody = fields?.body ?? '';
+  const patch = createPatch(oldBody, draftBody.trim());
+  const body = patch && patch.length < Buffer.from(oldBody, 'utf-8').length ? patch : draftBody;
+
+  const jsonMetadata = post?.json_metadata ?? {};
+  const meta = await extractMetadata({
+    body: draftBody,
+    thumbUrl,
+    videoThumbUrls,
+    fetchRatios: false,
+    postType: jsonMetadata.type,
+    contentType: jsonMetadata.content_type,
+  });
+
+  // Additive, matching the submit path: an edit must not drop a disclosure the
+  // author is not touching.
+  const aiTools = cleanAiTools({ ...(jsonMetadata?.ai_tools || {}), ...fields?.aiTools });
+  if (aiTools) {
+    meta.ai_tools = aiTools;
+  }
+
+  let jsonMeta;
+  try {
+    jsonMeta = makeJsonMetadataForUpdate(jsonMetadata, meta, tags);
+  } catch (e) {
+    jsonMeta = makeJsonMetadata(meta, tags);
+  }
+
+  return {
+    kind: 'comment',
+    op: {
+      author: username,
+      permlink: post?.permlink ?? '',
+      parent_author: post?.parent_author ?? '',
+      parent_permlink: post?.parent_permlink ?? '',
+      title: post?.parent_author ? '' : fields?.title ?? '',
+      body,
+      json_metadata: JSON.stringify(jsonMeta),
     },
   };
 };

--- a/src/utils/rcPayload.ts
+++ b/src/utils/rcPayload.ts
@@ -1,4 +1,10 @@
+import { enforceThreeSpeakBeneficiary } from '@ecency/sdk';
 import type { RcPrecheckPayload } from '@ecency/sdk';
+
+import {
+  ECENCY_SUPPORT_ACCOUNT,
+  injectEcencySupportBeneficiary,
+} from '../providers/ecency/supportBeneficiary';
 
 import { PostTypes } from '../constants/postTypes';
 import {
@@ -37,7 +43,15 @@ interface BuildArgs {
   videoThumbUrls?: string[];
   pollDraft?: any;
   rewardType?: string;
+  /** The stored beneficiary list for this draft, before submit-time additions. */
   beneficiaries?: any[];
+  /**
+   * Whether the draft has a beneficiary list the author set. The support
+   * beneficiary is only injected when it does not, matching the submit path.
+   */
+  hasExplicitBeneficiaries?: boolean;
+  /** The author's saved support percentage, read from cache rather than fetched. */
+  supportPercent?: number;
 }
 
 /** Hive requires a parent permlink; the editor falls back to this tag when the draft has none. */
@@ -76,6 +90,8 @@ export const buildEditorRcPayload = async ({
   pollDraft,
   rewardType,
   beneficiaries,
+  hasExplicitBeneficiaries,
+  supportPercent,
 }: BuildArgs): Promise<CommentRcPayload | undefined> => {
   const body = fields?.body ?? '';
   if (!username || !body) {
@@ -116,7 +132,18 @@ export const buildEditorRcPayload = async ({
   // never does.
   const options: any = isReply
     ? undefined
-    : makeOptions({ author: username, permlink, operationType: rewardType, beneficiaries });
+    : makeOptions({
+        author: username,
+        permlink,
+        operationType: rewardType,
+        beneficiaries: resolveSubmitBeneficiaries({
+          username,
+          body,
+          beneficiaries,
+          hasExplicitBeneficiaries,
+          supportPercent,
+        }),
+      });
 
   return {
     kind: 'comment',
@@ -133,6 +160,37 @@ export const buildEditorRcPayload = async ({
       ? { options: { beneficiaries: options.extensions?.[0]?.[1]?.beneficiaries } }
       : {}),
   };
+};
+
+/**
+ * The beneficiaries the post will really carry.
+ *
+ * Submit adds two rows the stored list does not have: a mandatory 3Speak
+ * beneficiary when the body embeds one of their videos, and the author's
+ * voluntary Ecency support row when they have not set a list of their own.
+ * Each row lands in comment_options, so pricing the stored list alone
+ * understates a post that gets either.
+ */
+const resolveSubmitBeneficiaries = ({
+  username,
+  body,
+  beneficiaries,
+  hasExplicitBeneficiaries,
+  supportPercent,
+}: {
+  username: string;
+  body: string;
+  beneficiaries?: any[];
+  hasExplicitBeneficiaries?: boolean;
+  supportPercent?: number;
+}) => {
+  const enforced = enforceThreeSpeakBeneficiary(beneficiaries ?? [], body);
+
+  if (hasExplicitBeneficiaries || username === ECENCY_SUPPORT_ACCOUNT || !supportPercent) {
+    return enforced;
+  }
+
+  return injectEcencySupportBeneficiary(enforced, supportPercent);
 };
 
 /**

--- a/src/utils/rcPayload.ts
+++ b/src/utils/rcPayload.ts
@@ -1,0 +1,85 @@
+import type { RcPrecheckPayload } from '@ecency/sdk';
+
+import { PostTypes } from '../constants/postTypes';
+import { cleanAiTools, extractMetadata, generatePermlink, makeJsonMetadata } from './editor';
+
+/**
+ * The comment member of the payload union. Narrowed because this builder only
+ * ever produces comments, which lets callers read op.body and friends without
+ * re-narrowing at every use.
+ */
+type CommentRcPayload = Extract<RcPrecheckPayload, { kind: 'comment' }>;
+
+interface BuildArgs {
+  /** The account that will sign. */
+  username: string;
+  /** The editor's live draft. */
+  fields: { title?: string; body?: string; tags?: string[]; aiTools?: any };
+  /** The parent post, when composing a reply. */
+  post?: any;
+  isReply?: boolean;
+  /**
+   * The reply permlink is time-derived, so only its length matters here and a
+   * fresh one per keystroke would be noise. Injectable for tests.
+   */
+  replyPermlink?: string;
+}
+
+/** Hive requires a parent permlink; the editor falls back to this tag when the draft has none. */
+const DEFAULT_TAG = 'hive-125125';
+
+/**
+ * Assembles the comment operation the editor is about to broadcast, for pricing.
+ *
+ * It has to be the real operation. RC cost tracks serialized transaction size,
+ * so an estimate built from the raw draft with tags-only metadata understates a
+ * post carrying a summary, images or links, and understating is the one
+ * direction that lets the chain reject a post we called affordable.
+ *
+ * Image ratios are deliberately not fetched: that would put requests on the
+ * network every time typing pauses, and the few bytes they add can only make
+ * the estimate lower, never a false alarm.
+ */
+export const buildEditorRcPayload = async ({
+  username,
+  fields,
+  post,
+  isReply,
+  replyPermlink,
+}: BuildArgs): Promise<CommentRcPayload | undefined> => {
+  const body = fields?.body ?? '';
+  if (!username || !body) {
+    return undefined;
+  }
+
+  const title = fields?.title ?? '';
+  const meta = await extractMetadata({
+    body,
+    fetchRatios: false,
+    ...(isReply ? { postType: PostTypes.COMMENT } : {}),
+  });
+
+  const aiTools = cleanAiTools(fields?.aiTools);
+  if (aiTools) {
+    meta.ai_tools = aiTools;
+  }
+
+  const tags = (fields?.tags ?? []).filter((tag: any) => tag && tag !== ' ');
+  const jsonMetadata = makeJsonMetadata(
+    meta,
+    isReply ? post?.json_metadata?.tags || ['ecency'] : tags,
+  );
+
+  return {
+    kind: 'comment',
+    op: {
+      author: username,
+      permlink: isReply ? replyPermlink ?? '' : generatePermlink(title),
+      parent_author: isReply ? post?.author ?? '' : '',
+      parent_permlink: isReply ? post?.permlink ?? '' : tags[0] || DEFAULT_TAG,
+      title: isReply ? '' : title,
+      body,
+      json_metadata: JSON.stringify(jsonMetadata),
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.83":
-  version "2.3.83"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.83.tgz#c61382f9ff8a16eb194811eee0e157b2c9502674"
-  integrity sha512-DXzv++9jHGaSKGbcIxqdTZpfCSjUSEFkQxime0Fx+qk5l+6X4kdyMdBpWm/hUiSaDkZAPv7rlbYluiRYtN0vZg==
+"@ecency/sdk@^2.3.85":
+  version "2.3.85"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.85.tgz#ec2b187c8a69ea74912005e508e3546b37ab89ee"
+  integrity sha512-mbrWU0OC/Yu1QP0IzrsySsrWV5HGFZs+LBwVDiW68NX0GVkMDMgiGLmelLIc6Pg/dANAaWNfCyvKZi05YY/few==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Closes #3496. Follow-up to #3495, which fixed the offer *after* a failure.

## Why

The first anyone heard of an RC shortfall was the chain rejecting a post they had already finished writing. Worse, for a large enough post waiting does not help: cost is dominated by serialized transaction size, and in the report that started this work it reached 23.3B RC against an account whose *maximum* was 21.4B. No amount of regeneration would have made that post publishable, and nothing in the app could say so.

## What

A non-blocking warning in the editor, shown while the draft is being written, when the estimated cost exceeds available RC. Tapping it opens the two-route offer sheet from #3495, so there is still one place that sells a top-up or a boost.

**`buildEditorRcPayload`** (`src/utils/rcPayload.ts`) assembles the operation the editor actually broadcasts: the same permlink shape, parent, tag fallback and full `makeJsonMetadata` output. Pricing the raw draft with tags-only metadata would understate a post carrying a summary, images or links, and understating is the one direction that lets the chain reject a post we called affordable.

Two deliberate departures, both in the safe direction:

- `fetchRatios` is off. Fetching image ratios would put requests on the network every time typing pauses. The few bytes they add can only make the estimate lower, never a false alarm.
- The reply permlink is generated by the caller rather than per rebuild, since it is time-derived and only its length feeds the estimate.

Costing parses the body, so it runs 800ms after typing stops rather than on every keystroke, and a draft that cannot be costed shows nothing rather than guessing.

**`useRcPrecheck`** (`src/hooks/useRcPrecheck.ts`) wraps `estimateRcPrecheck` over the three SDK queries. Without a payload the estimator prices a *minimal* operation, a lower bound that can miss a marginal case but never invents a warning, which is the right default for this.

## SDK bump

`^2.3.83` to `^2.3.85` for `estimateRcPrecheck`, which prices the actual operation the way the chain does rather than using the network average. The average is dominated by short replies: it told the account in that report it could afford 17 more posts when the next one needed more RC than the account could ever hold. Lockfile diff is the single `@ecency/sdk` entry.

## Testing

`src/utils/rcPayload.test.ts`, 10 cases: post and reply shapes, the five-word permlink cap, the `hive-125125` tag fallback, blank-tag filtering, AI disclosure, metadata size against a tags-only baseline, and the two nothing-to-price cases.

Full suite 855 (10 new), typecheck clean at 0 errors, lint identical to `development`.

## Device check

The estimator's arithmetic is covered by the SDK's own tests and was validated against a real rejection there, but the banner appearing at the right moment is worth confirming on a low-RC account: type past the threshold, confirm it appears, confirm tapping it opens the sheet, and confirm it does not appear for a normal short post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-publish warning that estimates Resource Credit requirements for posts, replies, and edits.
  * Supports estimates based on draft size, metadata, tags, media, polls, rewards, and beneficiaries.
  * Users can open the Resource Credit offer sheet when a draft may exceed available credits.
* **Localization**
  * Added English messaging for drafts that may be too large to publish.
* **Tests**
  * Added coverage for Resource Credit payload generation and editor edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->