### PR TITLE
fix(editor): stop earning post points for editing a post

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.85",
+    "@ecency/sdk": "^2.3.86",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -19,6 +19,7 @@ import {
   addDraft,
   updateDraft,
   enforceThreeSpeakBeneficiary,
+  type CommentPayload,
 } from '@ecency/sdk';
 import { SheetManager } from 'react-native-actions-sheet';
 import * as Sentry from '@sentry/react-native';
@@ -1627,8 +1628,16 @@ class EditorContainer extends Component<any, any> {
           AsyncStorage.setItem('temp-reply', '');
           this._handleSubmitSuccess();
         } else {
-          // Use SDK comment mutation for post edits (non-reply)
-          await this.props.commentMutation.mutateAsync({
+          // Use SDK comment mutation for post edits (non-reply). isUpdate keeps the SDK
+          // from recording a content activity: a comment op is identical on chain whether
+          // it publishes or edits, and makeJsonMetadataForUpdate deliberately keeps the
+          // original `app`, so without it an edit of a post published on another frontend
+          // earns post points and the daily quest tick here.
+          //
+          // Annotated rather than passed inline because `commentMutation` arrives through
+          // untyped props: an inline literal is not checked at all, so a misspelt isUpdate
+          // would typecheck clean and silently resume paying for edits.
+          const editPayload: CommentPayload = {
             author: currentAccount.name,
             permlink,
             parentAuthor: parentAuthor || '',
@@ -1636,7 +1645,10 @@ class EditorContainer extends Component<any, any> {
             title: title || '',
             body: newBody,
             jsonMetadata: jsonMeta,
-          });
+            isUpdate: true,
+          };
+
+          await this.props.commentMutation.mutateAsync(editPayload);
 
           this._handleSubmitSuccess();
           // update post query data

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.85":
-  version "2.3.85"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.85.tgz#ec2b187c8a69ea74912005e508e3546b37ab89ee"
-  integrity sha512-mbrWU0OC/Yu1QP0IzrsySsrWV5HGFZs+LBwVDiW68NX0GVkMDMgiGLmelLIc6Pg/dANAaWNfCyvKZi05YY/few==
+"@ecency/sdk@^2.3.86":
+  version "2.3.86"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.86.tgz#2a4e3f1a66a28f4d86f28bc35e4e4e560e5fcb88"
+  integrity sha512-8rMM+rcQJqNkiqLHR7SBM0hVWeM/2+FV6QyQFrEwphxQI7Q9j1MMEsfmrWxR6fxcUqR66CGGNji5eI3cWrGCag==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Closes #3498

## What

A `comment` op is identical on chain whether it publishes content or edits it, so the SDK cannot tell them apart on its own and was recording a type-100 POST activity for every post edit. `makeJsonMetadataForUpdate` deliberately keeps the original `app` tag, which is correct provenance behaviour, so editing a post first published on another frontend was credited here as a post published here: post points plus the daily quest tick.

`@ecency/sdk` 2.3.86 adds `isUpdate` to the comment payload. `_submitEdit` now sets it on the non-reply branch.

Reply edits go through `useUpdateReply`, which stopped recording activity entirely in the same release, so they need no change here beyond the bump. That also covers `postOptionsModal`, which uses the same mutation.

Checked the other call sites: `usePostSubmitter` always sets a `parentAuthor` and only ever creates new content, so it keeps recording, correctly.

## The typed payload is load-bearing

`commentMutation` arrives through untyped props on a class component, so an inline object literal is checked against nothing. I verified this: a deliberate `isUpdatex: true` passed `yarn typecheck` clean with 0 errors.

Annotating the payload as `CommentPayload` restores the check. The same typo now fails:

```
error TS2561: Object literal may only specify known properties, but 'isUpdatex'
does not exist in type 'CommentPayload'. Did you mean to write 'isUpdate'?
```

Without that, a future rename or typo would silently resume paying for edits, with nothing failing.

## Verification

- `yarn install --frozen-lockfile` exits 0, so the lockfile edit is consistent. Deps and peerDeps are byte-identical between 2.3.85 and 2.3.86, only the tarball and integrity changed.
- Installed `@ecency/sdk` is 2.3.86 and carries the compiled gate: `function hp(e){return e.isUpdate?null:e.parentAuthor?110:100}`.
- `yarn typecheck`: 0 errors, baseline 0. Typo variant fails as above.
- `yarn test:ci`: 870 passed, 1 skipped.
- Prettier clean, ESLint 0 errors with 13 warnings, identical to the same file on `development`.

## Context

Third and last piece of the fix for edits earning content rewards, reported by a community member who spotted an account holding the leaderboard quest badge while publishing from another frontend.

- ecency/ePoints#53 is the actual gate, merged and deployed. It refuses the reward server-side, so it covers every client including builds already in the wild. Verified on live traffic: 3 real edits refused with zero points minted, while 105 genuine posts and comments verified normally.
- ecency/vision-web#1491 is the same client-side change for web, merged.

This one stops the pointless request being made at all. It is hygiene rather than the gate, since the backend already refuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of editing existing posts.
  * Ensured edited posts are correctly recognized as updates, preserving expected editing behavior.
  * Added stronger validation for post edit submissions to help prevent malformed updates and improve overall editor stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->