### PR TITLE
Dim muted post cards instead of blanking them, matching web

### DIFF
--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -16,6 +16,7 @@ import ROUTES from '../../../constants/routeNames';
 import { ContentType, MutedReason } from '../../../providers/hive/hive.types';
 import { isCommunity } from '../../../utils/communityValidation';
 import { useImageReveal } from '../../../hooks/useImageReveal';
+import { useMutedReveal } from '../../../hooks/useMutedReveal';
 import { HiddenImagePlaceholder } from '../../hiddenImagePlaceholder';
 
 // i.ecency.com: same imagehoster backend as images.ecency.com on an
@@ -87,6 +88,14 @@ const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Prop
   const _isMuted = content?.isMuted;
   const _isCommunityPost = isCommunity(content?.community);
 
+  // Matches web: muted content is never blanked out, the card body is only dimmed
+  // behind a hint the user can tap to clear.
+  const { isDimmed, reveal: revealMuted } = useMutedReveal(
+    !!_isMuted,
+    content?.author,
+    content?.permlink,
+  );
+
   // State the reason that actually fired. Posts cached by an older app version carry
   // isMuted without a reason, so those fall back to the generic moderation message.
   const _mutedText = useMemo(() => {
@@ -128,9 +137,11 @@ const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Prop
     });
   };
 
+  // Muted posts keep their real thumbnail (the card dims instead), so only the
+  // nsfw setting can swap the image out here.
   const images = useMemo(() => {
     let imgs = { image: DEFAULT_IMAGE, thumbnail: DEFAULT_IMAGE };
-    if (!_isMuted && content.thumbnail) {
+    if (content.thumbnail) {
       if (nsfw !== '0' && content.nsfw) {
         imgs = { image: NSFW_IMAGE, thumbnail: NSFW_IMAGE };
       } else {
@@ -138,7 +149,7 @@ const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Prop
       }
     }
     return imgs;
-  }, [_isMuted, content.thumbnail, content.nsfw, content.image, nsfw]);
+  }, [content.thumbnail, content.nsfw, content.image, nsfw]);
 
   const original = content?.json_metadata?.image?.[0];
   const isGif = useMemo(() => /\.gif$/i.test(original), [original]);
@@ -169,73 +180,87 @@ const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Prop
 
   return (
     <View style={styles.postBodyWrapper}>
-      <TouchableOpacity activeOpacity={0.8} style={styles.hiddenImages} onPress={_onPress}>
-        {isHidden ? (
-          hasContentImage && (
-            <View style={styles.imageWrapper}>
-              <HiddenImagePlaceholder
-                width={imgWidth}
-                height={Math.min(imgHeight, dim.height)}
-                onPress={reveal}
-              />
-            </View>
-          )
-        ) : (
-          <View style={styles.imageWrapper}>
-            <ExpoImage
-              ref={imgRef}
-              pointerEvents="none"
-              source={{ uri: imageUri }}
-              style={[
-                styles.thumbnail,
-                {
-                  width: imgWidth,
-                  height: Math.min(imgHeight, dim.height),
-                },
-              ]}
-              contentFit={resizeMode}
-              autoplay={true}
-              onLoad={(evt) => {
-                const loadedRatio = evt.source.width / evt.source.height;
-
-                if (!Number.isFinite(loadedRatio) || loadedRatio <= 0) {
-                  return;
-                }
-
-                // Keep the cached value width-independent so orientation changes
-                // recalculate height from the current viewport instead of reusing
-                // a previous landscape/portrait pixel height.
-                if (
-                  imageLayout.contentKey === contentKey &&
-                  Math.abs(loadedRatio - imageRatio) < 0.01
-                ) {
-                  return;
-                }
-
-                setImageLayout({
-                  contentKey,
-                  ratio: loadedRatio,
-                });
-              }}
-            />
-            {isGif && (
-              <View style={styles.gifBadge}>
-                <Text style={styles.gifBadgeText}>GIF</Text>
-              </View>
-            )}
+      {isDimmed && (
+        <TouchableOpacity
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          style={styles.mutedHint}
+          onPress={revealMuted}
+        >
+          <View style={styles.mutedHintBadge}>
+            <Text style={styles.mutedHintBadgeText}>!</Text>
           </View>
-        )}
-
-        <View style={[styles.postDescripton]}>
-          {_isMuted ? (
-            <Text style={styles.promotedText}>{_mutedText}</Text>
+          <Text style={styles.mutedHintText}>
+            {_mutedText}{' '}
+            <Text style={styles.mutedHintAction}>
+              {intl.formatMessage({ id: 'post.muted_reveal' })}
+            </Text>
+          </Text>
+        </TouchableOpacity>
+      )}
+      <TouchableOpacity activeOpacity={0.8} style={styles.hiddenImages} onPress={_onPress}>
+        <View style={isDimmed ? styles.dimmedContent : undefined}>
+          {isHidden ? (
+            hasContentImage && (
+              <View style={styles.imageWrapper}>
+                <HiddenImagePlaceholder
+                  width={imgWidth}
+                  height={Math.min(imgHeight, dim.height)}
+                  onPress={reveal}
+                />
+              </View>
+            )
           ) : (
-            <>
-              {!!_featuredText && <Text style={styles.promotedText}>{_featuredText}</Text>}
-              <Text style={styles.title}>{content.title}</Text>
-              <Text style={styles.summary}>{content.summary}</Text>
-            </>
+            <View style={styles.imageWrapper}>
+              <ExpoImage
+                ref={imgRef}
+                pointerEvents="none"
+                source={{ uri: imageUri }}
+                style={[
+                  styles.thumbnail,
+                  {
+                    width: imgWidth,
+                    height: Math.min(imgHeight, dim.height),
+                  },
+                ]}
+                contentFit={resizeMode}
+                autoplay={true}
+                onLoad={(evt) => {
+                  const loadedRatio = evt.source.width / evt.source.height;
+
+                  if (!Number.isFinite(loadedRatio) || loadedRatio <= 0) {
+                    return;
+                  }
+
+                  // Keep the cached value width-independent so orientation changes
+                  // recalculate height from the current viewport instead of reusing
+                  // a previous landscape/portrait pixel height.
+                  if (
+                    imageLayout.contentKey === contentKey &&
+                    Math.abs(loadedRatio - imageRatio) < 0.01
+                  ) {
+                    return;
+                  }
+
+                  setImageLayout({
+                    contentKey,
+                    ratio: loadedRatio,
+                  });
+                }}
+              />
+              {isGif && (
+                <View style={styles.gifBadge}>
+                  <Text style={styles.gifBadgeText}>GIF</Text>
+                </View>
+              )}
+            </View>
           )}
+
+          <View style={[styles.postDescripton]}>
+            {!!_featuredText && <Text style={styles.promotedText}>{_featuredText}</Text>}
+            <Text style={styles.title}>{content.title}</Text>
+            <Text style={styles.summary}>{content.summary}</Text>
+          </View>
         </View>
       </TouchableOpacity>
     </View>

--- a/src/components/postCard/styles/postCard.styles.ts
+++ b/src/components/postCard/styles/postCard.styles.ts
@@ -106,4 +106,41 @@ export default EStyleSheet.create({
     marginTop: 6,
     marginBottom: -8,
   },
+
+  // Muted/downvoted content: a hint above the card body, which is dimmed rather
+  // than hidden. Mirrors the website's entry list item treatment.
+  mutedHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingBottom: 8,
+  },
+  // Orange is not in the theme palette; these are the web badge's colors
+  // (tailwind orange-500 at 20% and full), which read on both themes.
+  mutedHintBadge: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    marginRight: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(249, 115, 22, 0.2)',
+  },
+  mutedHintBadgeText: {
+    fontSize: 11,
+    fontWeight: 'bold',
+    lineHeight: 14,
+    color: '#f97316',
+  },
+  mutedHintText: {
+    flex: 1,
+    fontSize: 13,
+    color: '$primaryDarkGray',
+  },
+  mutedHintAction: {
+    color: '$primaryBlue',
+  },
+  dimmedContent: {
+    opacity: 0.5,
+  },
 });

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1073,6 +1073,7 @@
     "community_muted": "Content muted for community guidelines violation",
     "muted_low_reputation": "Content from a low reputation account",
     "muted_downvoted": "Content downvoted by users",
+    "muted_reveal": "Tap to reveal",
     "promoted": "PROMOTED",
     "image_saved": "Image saved to Photo Gallery",
     "words": "Words",

--- a/src/hooks/useMutedReveal.ts
+++ b/src/hooks/useMutedReveal.ts
@@ -1,0 +1,30 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import {
+  getMutedPostKey,
+  isMutedPostRevealed,
+  revealMutedPost,
+  subscribeToRevealedMutedPosts,
+} from '../utils/revealedMutedPosts';
+
+/**
+ * Gates the dimmed treatment of a muted post card behind a tap, matching web:
+ * the content is never hidden, only dimmed with a hint above it until the user
+ * taps the hint.
+ *
+ * `isDimmed` is true while the post is muted and this particular post has not
+ * been revealed yet.
+ */
+export const useMutedReveal = (isMuted: boolean, author?: string, permlink?: string) => {
+  const postKey = getMutedPostKey(author, permlink);
+
+  const isRevealed = useSyncExternalStore(
+    subscribeToRevealedMutedPosts,
+    // Snapshot is a boolean scoped to this post, so revealing one card does not
+    // re-render every other card on screen.
+    () => isMutedPostRevealed(postKey),
+  );
+
+  const reveal = useCallback(() => revealMutedPost(postKey), [postKey]);
+
+  return { isDimmed: isMuted && !isRevealed, reveal };
+};

--- a/src/utils/revealedMutedPosts.test.ts
+++ b/src/utils/revealedMutedPosts.test.ts
@@ -1,0 +1,56 @@
+import {
+  clearRevealedMutedPosts,
+  getMutedPostKey,
+  isMutedPostRevealed,
+  revealMutedPost,
+  subscribeToRevealedMutedPosts,
+} from './revealedMutedPosts';
+
+describe('revealedMutedPosts', () => {
+  beforeEach(() => {
+    clearRevealedMutedPosts();
+  });
+
+  it('builds a key only when both author and permlink are present', () => {
+    expect(getMutedPostKey('offgridlife', 'good-night')).toBe('offgridlife/good-night');
+    expect(getMutedPostKey('offgridlife', undefined)).toBe('');
+    expect(getMutedPostKey(undefined, 'good-night')).toBe('');
+  });
+
+  it('reveals a single post without revealing the others', () => {
+    revealMutedPost('alice/one');
+
+    expect(isMutedPostRevealed('alice/one')).toBe(true);
+    expect(isMutedPostRevealed('bob/two')).toBe(false);
+  });
+
+  it('treats an empty key as never revealed', () => {
+    revealMutedPost('');
+
+    expect(isMutedPostRevealed('')).toBe(false);
+    expect(isMutedPostRevealed(undefined)).toBe(false);
+  });
+
+  it('notifies subscribers once per newly revealed post', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToRevealedMutedPosts(listener);
+
+    revealMutedPost('alice/one');
+    // Already revealed, so nothing changed and nothing to notify about.
+    revealMutedPost('alice/one');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    revealMutedPost('bob/two');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears reveals so a fresh session starts dimmed again', () => {
+    revealMutedPost('alice/one');
+    clearRevealedMutedPosts();
+
+    expect(isMutedPostRevealed('alice/one')).toBe(false);
+  });
+});

--- a/src/utils/revealedMutedPosts.ts
+++ b/src/utils/revealedMutedPosts.ts
@@ -1,0 +1,35 @@
+/**
+ * Session-scoped record of muted posts the user tapped to reveal in the feed.
+ *
+ * Mirrors `revealedImages`: kept in memory rather than component state so a
+ * reveal survives FlashList cell recycling (state on the cell would otherwise
+ * carry over to whichever post lands in the recycled cell next), and is not
+ * persisted so a fresh session starts with the hint back in place.
+ */
+const revealedPosts = new Set<string>();
+const listeners = new Set<() => void>();
+
+export const getMutedPostKey = (author?: string, permlink?: string) =>
+  author && permlink ? `${author}/${permlink}` : '';
+
+export const revealMutedPost = (postKey?: string) => {
+  if (!postKey || revealedPosts.has(postKey)) {
+    return;
+  }
+  revealedPosts.add(postKey);
+  listeners.forEach((listener) => listener());
+};
+
+export const isMutedPostRevealed = (postKey?: string) => !!postKey && revealedPosts.has(postKey);
+
+export const subscribeToRevealedMutedPosts = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const clearRevealedMutedPosts = () => {
+  revealedPosts.clear();
+  listeners.forEach((listener) => listener());
+};


### PR DESCRIPTION
Closes #3500

Feed cards blanked out muted content: the thumbnail was swapped for the generic no-image graphic and the title and summary were replaced by a single moderation line. `isMuted` covers moderator mutes (`stats.gray` / `stats.hide`), authors under the reputation threshold and heavily downvoted posts, so a fair amount of ordinary content rendered as an empty card.

The website keeps everything visible and only dims it, so the same post looked completely different depending on the client.

- thumbnail, title and summary now render as usual for muted posts (nsfw keeps its own placeholder)
- the reason moves into a hint row above the body: `!` badge, the reason, then "Tap to reveal"
- the body sits at 50% opacity until the hint is tapped, then goes back to full opacity
- reveals live in `src/utils/revealedMutedPosts.ts`, a session-scoped store mirroring `revealedImages`, so a reveal survives FlashList cell recycling instead of leaking into the next post that lands in the cell

Side note found on the way, not changed here: `postsListContainer` drops posts by authors the viewer has muted from the list entirely, while web shows those with a "Muted author, Reveal content" hint. That is a separate behaviour from this one.

Not verified on a device yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Muted posts now remain visible in a dimmed state instead of being replaced entirely.
  * Added a tappable “Tap to reveal” prompt for viewing muted post content.
  * NSFW images continue to use image substitution, while existing hidden-image and GIF behavior is preserved.

* **Tests**
  * Added coverage for muted-post reveal behavior and session state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->