### PR TITLE
Guard the feed item before reading its author

### DIFF
--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -108,7 +108,9 @@ const postsListContainer = (
 
     // Authors the viewer muted are dropped from the list rather than dimmed, and the
     // website now does the same. Shared helper so both stay on one definition.
-    _data = _data.filter((item) => !isAuthorMuted(item.author, mutes) && !!item?.author);
+    // Author guard first: the optional chaining here has always implied the feed
+    // can hand us a nullish item, and everything after it dereferences one.
+    _data = _data.filter((item) => !!item?.author && !isAuthorMuted(item.author, mutes));
 
     // Create Set for O(1) lookup instead of O(n) filter
     const existingPermlinks = new Set(_data.map((post) => `${post.author}/${post.permlink}`));
@@ -116,8 +118,11 @@ const postsListContainer = (
     const _promotedPosts =
       promotedPosts && Array.isArray(promotedPosts)
         ? promotedPosts.filter((item) => {
+            if (!item?.author) {
+              return false;
+            }
             const notInPosts = !existingPermlinks.has(`${item.author}/${item.permlink}`);
-            return !isAuthorMuted(item.author, mutes) && !!item?.author && notInPosts;
+            return !isAuthorMuted(item.author, mutes) && notInPosts;
           })
         : [];
 


### PR DESCRIPTION
Follow-up to #3503, from a review finding on it.

Both mute filters in `postsListContainer` read `item.author` and then checked `!!item?.author`, so the optional chaining that exists to tolerate a nullish item sat after two dereferences of it. The guard goes first now.

`isAuthorMuted` is null-safe on its own (`!!author && !!mutedAuthors?.includes(author)`), so this was never the throw the review read it as, and the ordering predates #3503. It still says the opposite of what the code means, and a nullish item would take the feed down at `item.author` rather than being filtered out.

872 unit tests pass, `tsc --noEmit` clean, lint clean.