### PR TITLE
Render wallet activity newest first

### DIFF
--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -20,7 +20,11 @@ import {
   useBroadcastMutation,
   buildRecurrentTransferOp,
 } from '@ecency/sdk';
-import { getHistoryOpsForSymbol, matchesAssetTicker } from '../../../utils/walletHistory';
+import {
+  getHistoryOpsForSymbol,
+  matchesAssetTicker,
+  orderChainActivities,
+} from '../../../utils/walletHistory';
 import { ASSET_IDS } from '../../../constants/defaultAssets';
 import { resolvePointType } from '../../../constants/options/points';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
@@ -44,7 +48,7 @@ import {
 } from '../../../utils/wallet';
 import { convertEngineHistory } from '../../hive-engine/converters';
 import { updateCurrentAccount } from '../../../redux/actions/accountAction';
-import { ProfileToken } from '../../../redux/reducers/walletReducer';
+import { CoinActivity, ProfileToken } from '../../../redux/reducers/walletReducer';
 
 interface ClaimRewardsMutationVars {
   symbol: string;
@@ -491,11 +495,13 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
       return transferTypes.includes(opType);
     });
 
-    const activities = transfers.map((item) =>
-      groomingTransactionData(item, globalProps.hivePerMVests),
-    );
+    const activities = transfers
+      .map((item) => groomingTransactionData(item, globalProps.hivePerMVests))
+      .filter((item): item is CoinActivity => matchesAssetTicker(item, symbol));
 
-    return activities.filter((item) => matchesAssetTicker(item, symbol));
+    // A page lands oldest-first and the next page is an older window appended at the end,
+    // so the raw order puts stale rows on top and reads as a wallet that stopped updating.
+    return orderChainActivities(activities);
   }, [
     pointsQuery.data?.transactions,
     (chainQuery.data as any)?.pages,

--- a/src/utils/walletHistory.test.ts
+++ b/src/utils/walletHistory.test.ts
@@ -3,6 +3,7 @@ import {
   HIVE_LAYER_HISTORY_OPS,
   getHistoryOpsForSymbol,
   matchesAssetTicker,
+  orderChainActivities,
 } from './walletHistory';
 import { groomingTransactionData, transferTypes } from './wallet';
 
@@ -150,11 +151,15 @@ describe('wallet history pipeline', () => {
     },
   ];
 
-  const render = (symbol: string) =>
-    witnessPage
-      .filter((tx) => transferTypes.includes(tx.type))
-      .map((tx) => groomingTransactionData(tx, hivePerMVests))
-      .filter((activity) => matchesAssetTicker(activity, symbol));
+  const render = (symbol: string, page: any[] = witnessPage) =>
+    orderChainActivities(
+      page
+        .filter((tx) => transferTypes.includes(tx.type))
+        .map((tx) => groomingTransactionData(tx, hivePerMVests))
+        .filter((activity): activity is NonNullable<typeof activity> =>
+          matchesAssetTicker(activity, symbol),
+        ),
+    );
 
   it('renders rows on the HIVE and HBD tabs', () => {
     expect(render('HIVE')).toHaveLength(1);
@@ -172,5 +177,50 @@ describe('wallet history pipeline', () => {
     ['HIVE', 'HBD', 'HP'].forEach((symbol) => {
       expect(render(symbol).map((activity) => activity!.textKey)).not.toContain('producer_reward');
     });
+  });
+
+  // The reported bug: the app showed two-day-old transfers above today's and read as a
+  // wallet that had stopped updating. A page arrives oldest-first and the next page is an
+  // older window appended after it, so the raw stream is old->new, then older->newer.
+  it('renders the newest operation first across a page boundary', () => {
+    const newestWindow = [
+      { num: 20, type: 'transfer', timestamp: '2026-08-15T15:07:48', amount: '0.002 HIVE' },
+      { num: 21, type: 'transfer', timestamp: '2026-08-16T21:02:48', amount: '20.000 HIVE' },
+      { num: 22, type: 'transfer', timestamp: '2026-08-17T03:30:27', amount: '0.016 HIVE' },
+    ];
+    const olderWindow = [
+      { num: 17, type: 'transfer', timestamp: '2026-08-13T09:00:00', amount: '1.000 HIVE' },
+      { num: 18, type: 'transfer', timestamp: '2026-08-14T09:00:00', amount: '2.000 HIVE' },
+      { num: 19, type: 'transfer', timestamp: '2026-08-15T09:00:00', amount: '3.000 HIVE' },
+    ];
+
+    const rows = render('HIVE', [...newestWindow, ...olderWindow]);
+
+    expect(rows.map((activity) => activity!.trxIndex)).toEqual([22, 21, 20, 19, 18, 17]);
+  });
+});
+
+describe('orderChainActivities', () => {
+  const activity = (trxIndex: number, value = '1.000 HIVE') => ({
+    trxIndex,
+    iconType: 'MaterialIcons',
+    value,
+  });
+
+  it('collapses a repeated operation to one row', () => {
+    const rows = orderChainActivities([activity(5), activity(4), activity(5)]);
+
+    expect(rows.map((row) => row.trxIndex)).toEqual([5, 4]);
+  });
+
+  it('leaves the caller its own array', () => {
+    const input = [activity(1), activity(3)];
+    orderChainActivities(input);
+
+    expect(input.map((row) => row.trxIndex)).toEqual([1, 3]);
+  });
+
+  it('handles an empty history', () => {
+    expect(orderChainActivities([])).toEqual([]);
   });
 });

--- a/src/utils/walletHistory.test.ts
+++ b/src/utils/walletHistory.test.ts
@@ -223,4 +223,33 @@ describe('orderChainActivities', () => {
   it('handles an empty history', () => {
     expect(orderChainActivities([])).toEqual([]);
   });
+
+  // Dropping a row is the failure this function exists to prevent, so a row that arrives
+  // without a usable num must survive rather than collide with every other such row on a
+  // single undefined key.
+  it('keeps rows that have no usable trxIndex', () => {
+    const rows = orderChainActivities([
+      { trxIndex: undefined as any, iconType: 'MaterialIcons', value: '1.000 HIVE' },
+      activity(7),
+      { trxIndex: NaN, iconType: 'MaterialIcons', value: '2.000 HIVE' },
+      activity(9),
+    ]);
+
+    expect(rows).toHaveLength(4);
+    expect(rows.slice(0, 2).map((row) => row.trxIndex)).toEqual([9, 7]);
+  });
+
+  it('orders unkeyed rows among themselves by timestamp', () => {
+    const older = {
+      trxIndex: undefined as any,
+      iconType: 'MaterialIcons',
+      value: '1.000 HIVE',
+      created: '2026-08-15T10:00:00',
+    };
+    const newer = { ...older, value: '2.000 HIVE', created: '2026-08-17T10:00:00' };
+
+    const rows = orderChainActivities([older, newer]);
+
+    expect(rows.map((row) => row.created)).toEqual([newer.created, older.created]);
+  });
 });

--- a/src/utils/walletHistory.ts
+++ b/src/utils/walletHistory.ts
@@ -91,3 +91,29 @@ export const matchesAssetTicker = (activity: CoinActivity | null, symbol: string
   const tickers = symbol === 'HP' ? ['HP', 'VESTS'] : [symbol];
   return tickers.some((ticker) => activity.value!.includes(ticker));
 };
+
+/**
+ * Newest first, no repeats.
+ *
+ * `condenser_api.get_account_history` answers a page in ASCENDING `num` order, so the
+ * OLDEST operation of the window arrives at index 0 and rendering a page as it lands puts
+ * two-day-old rows above today's. Paging compounds it: the next page is an older window
+ * appended at the END, itself ascending, so the list reads old->new, then older->newer.
+ * Both of those read to a user as "the wallet stopped updating", since nothing is
+ * actually missing and refreshing changes nothing they can see.
+ *
+ * `num` (groomed to `trxIndex`) is unique and monotonic per account, so it orders exactly
+ * with no timestamp ties to break, and it doubles as the dedupe key. The web wallet sorts
+ * the same field the same way.
+ */
+export const orderChainActivities = (activities: CoinActivity[]): CoinActivity[] => {
+  const byTrxIndex = new Map<number, CoinActivity>();
+
+  activities.forEach((activity) => {
+    if (!byTrxIndex.has(activity.trxIndex)) {
+      byTrxIndex.set(activity.trxIndex, activity);
+    }
+  });
+
+  return [...byTrxIndex.values()].sort((a, b) => Number(b.trxIndex) - Number(a.trxIndex));
+};

--- a/src/utils/walletHistory.ts
+++ b/src/utils/walletHistory.ts
@@ -92,6 +92,31 @@ export const matchesAssetTicker = (activity: CoinActivity | null, symbol: string
   return tickers.some((ticker) => activity.value!.includes(ticker));
 };
 
+const createdAt = (activity: CoinActivity): number => {
+  const parsed = Date.parse(activity.created ?? '');
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * Total order, so `sort` cannot behave differently between engines.
+ *
+ * Rows carrying a usable `num` come first and are ordered by it. Anything without one
+ * cannot be compared against them consistently, so it sinks below the whole set and falls
+ * back to its timestamp rather than producing a NaN comparison.
+ */
+const compareNewestFirst = (a: CoinActivity, b: CoinActivity): number => {
+  const ai = Number(a.trxIndex);
+  const bi = Number(b.trxIndex);
+  const aRanked = Number.isFinite(ai);
+  const bRanked = Number.isFinite(bi);
+
+  if (aRanked !== bRanked) {
+    return aRanked ? -1 : 1;
+  }
+
+  return aRanked ? bi - ai : createdAt(b) - createdAt(a);
+};
+
 /**
  * Newest first, no repeats.
  *
@@ -107,13 +132,25 @@ export const matchesAssetTicker = (activity: CoinActivity | null, symbol: string
  * the same field the same way.
  */
 export const orderChainActivities = (activities: CoinActivity[]): CoinActivity[] => {
-  const byTrxIndex = new Map<number, CoinActivity>();
+  const seen = new Set<number>();
+  const ordered: CoinActivity[] = [];
 
   activities.forEach((activity) => {
-    if (!byTrxIndex.has(activity.trxIndex)) {
-      byTrxIndex.set(activity.trxIndex, activity);
+    const trxIndex = Number(activity.trxIndex);
+
+    // A row that reached here without a usable `num` cannot be keyed or ordered by one.
+    // Keep it: collapsing several onto a single `undefined` key would silently drop rows,
+    // which is the failure this function exists to prevent, not one to introduce.
+    if (!Number.isFinite(trxIndex)) {
+      ordered.push(activity);
+      return;
+    }
+
+    if (!seen.has(trxIndex)) {
+      seen.add(trxIndex);
+      ordered.push(activity);
     }
   });
 
-  return [...byTrxIndex.values()].sort((a, b) => Number(b.trxIndex) - Number(a.trxIndex));
+  return ordered.sort(compareNewestFirst);
 };


### PR DESCRIPTION
Closes #3505

`condenser_api.get_account_history` answers a page in ascending `num` order, so the oldest operation of the window arrives at index 0. `useActivitiesQuery` handed that straight to the list, so the wallet opened on rows from two days ago while today's transfers sat below the fold. Paging compounded it: the next page is an older window appended at the end, itself ascending.

The engine branch of `_data` already sorted by `created` descending. Only the chain branch had no sort.

`orderChainActivities` dedupes by `trxIndex` (the groomed `num`, unique and monotonic per account) then sorts descending, which is what `apps/web/.../wallet/(token)/hive/_page.tsx` does with the same field.

## Verified

Against a live node for the reporting account, with the app's own HIVE bitmask and its op-type and ticker filters applied, the rendered order was:

```
row  1  2026-08-15T15:07:48  transfer              0.002 HIVE
row  2  2026-08-15T16:02:24  transfer_to_vesting  14.000 HIVE
...
row 33  2026-08-17T03:39:12  claim_reward_balance 13.615 HIVE
```

Rows 1 to 3 are exactly what the report screenshot showed at the top of the app. The transfers the user was looking for were rows 19 and 20 of 33.

Unit tests cover the page boundary (newest window then older window, asserting a single descending sequence), the dedupe and that the input array is left alone.

Still wants a device pass on HIVE, HBD and HP, including a scroll past the first page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet history now consistently displays the newest activities first, including across multiple pages.
  * Removed duplicate wallet activities from history results.
  * Improved activity filtering and ordering for more reliable transaction history.

* **Tests**
  * Added coverage for ordering, duplicate removal, empty histories, and preserving source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->