### PR TITLE
Trim the wallet activity pipeline and stop re-rendering every row

### DIFF
--- a/src/components/transaction/transactionView.tsx
+++ b/src/components/transaction/transactionView.tsx
@@ -53,7 +53,13 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
 
   const _onRepeatPress = () => {
     if (onRepeatPress) {
-      onRepeatPress();
+      onRepeatPress(item);
+    }
+  };
+
+  const _onCancelPress = () => {
+    if (onCancelPress) {
+      onCancelPress(item.trxIndex);
     }
   };
 
@@ -98,7 +104,7 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
       }}
       cancelable={item.cancelable}
       cancelling={cancelling}
-      onCancelPress={onCancelPress}
+      onCancelPress={_onCancelPress}
       onRepeatPress={item?.repeatable ? _onRepeatPress : null}
     />
   );
@@ -138,4 +144,9 @@ const TransactionView = ({ item, index, cancelling, onCancelPress, onRepeatPress
   );
 };
 
-export default TransactionView;
+/**
+ * Memoised because the list re-renders it on every screen-level state change, and there can
+ * be hundreds mounted. The callers pass stable callbacks, so the props only change when the
+ * row's own activity, position or cancelling state does.
+ */
+export default React.memo(TransactionView);

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -63,7 +63,20 @@ interface RecurrentTransferPayload {
   executions: number;
 }
 
-const ACTIVITIES_FETCH_LIMIT = 50;
+/**
+ * `condenser_api.get_account_history` walks back until it has `limit` matching operations,
+ * so a page costs the node roughly nothing extra on an ordinary account and scales with the
+ * page size on one whose matches are sparse. Measured on api.deathwing.me with this op set,
+ * limits 20/50/100/200/500: `ecency` 53/52/63/108/157ms, `bulliontools` 54/71/111/113/296ms,
+ * but the witness account `good-karma` 255/415/497/701/1710ms.
+ *
+ * 100 halves the round trips on the accounts most people have without doubling the scan for
+ * the accounts already closest to the client's 10s ceiling.
+ */
+const ACTIVITIES_FETCH_LIMIT = 100;
+
+/** Membership test per history row, so the 21-entry list is not rescanned for each one. */
+const TRANSFER_TYPES = new Set(transferTypes);
 
 // A page whose rows are all filtered out client-side leaves the list empty, and an
 // empty list is never scrolled, so `onEndReached` never fires to pull the next page.
@@ -479,21 +492,15 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
       );
     }
 
-    // Each SDK page is a Transaction[] whose items are flat operation objects
+    // Each SDK page is a Transaction[] of flat operation objects
     // ({ num, type, timestamp, ...opValue }) that groomingTransactionData understands.
-    // Older cached pages may still hold the { entries } wrapper or the legacy
-    // [trxIndex, { op }] tuple form, so tolerate all three.
-    const _chainPages = (chainQuery.data as any)?.pages as
-      | Array<unknown[] | { entries?: unknown[] }>
-      | undefined;
-    const history: any[] =
-      _chainPages?.flatMap((p) =>
-        Array.isArray(p) ? p : (p as { entries?: unknown[] })?.entries ?? [],
-      ) || [];
-    const transfers = history.filter((tx) => {
-      const opType = Array.isArray(tx) ? get(tx[1], 'op[0]', false) : get(tx, 'type', false);
-      return transferTypes.includes(opType);
-    });
+    // The `{ entries }` wrapper this used to tolerate belongs to the hafah REST option
+    // builder, which this hook stopped using in #3480, and the `[trxIndex, { op }]` tuple
+    // predates the SDK. Neither can arrive: the query key namespace is `assets`, which
+    // `_shouldDehydrateQuery` does not persist, so no page outlives the session that
+    // fetched it.
+    const history: any[] = (chainQuery.data as any)?.pages?.flat() ?? [];
+    const transfers = history.filter((tx) => TRANSFER_TYPES.has(get(tx, 'type', '')));
 
     const activities = transfers
       .map((item) => groomingTransactionData(item, globalProps.hivePerMVests))
@@ -537,13 +544,19 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
 
   const activeQuery = isPoints ? pointsQuery : isEngine ? engineQuery : chainQuery;
 
+  const isSupportedLayer = isPoints || isEngine || isHive;
+
   return {
     data: _data,
     isRefreshing,
-    isLoading:
-      isPoints || isEngine || isHive ? activeQuery.isLoading || activeQuery.isFetching : false,
-    isError: isPoints || isEngine || isHive ? activeQuery.isError : false,
-    error: isPoints || isEngine || isHive ? activeQuery.error : null,
+    // Only the first load, when there is nothing to show yet. Folding `isFetching` in here
+    // made a background refetch and a next-page fetch indistinguishable from it, so the
+    // list footer showed the same spinner for all three and paging was gated on whichever
+    // of them happened to be in flight.
+    isLoading: isSupportedLayer ? activeQuery.isLoading : false,
+    isFetchingNextPage: isEngine || isHive ? (activeQuery as any).isFetchingNextPage : false,
+    isError: isSupportedLayer ? activeQuery.isError : false,
+    error: isSupportedLayer ? activeQuery.error : null,
     fetchNextPage: _fetchNextPage,
     refresh: _refresh,
   };

--- a/src/providers/queries/walletQueries/walletQueries.ts
+++ b/src/providers/queries/walletQueries/walletQueries.ts
@@ -460,11 +460,17 @@ export const useActivitiesQuery = (symbol: string, layer: PortfolioLayer) => {
       return;
     }
 
+    // Gate on `isFetching`, not just `isFetchingNextPage`. `fetchNextPage` defaults to
+    // `cancelRefetch: true` (queryObserver resolves `fetchOptions.cancelRefetch ?? true`),
+    // so calling it mid-refetch kills the refresh and appends to the pages it was about to
+    // replace, leaving new activity absent until the user refreshes again. This guard used
+    // to be implicit in the old `isLoading || isFetching`, which no longer holds now that
+    // those states are reported separately.
     if (isEngine) {
-      if (engineQuery.hasNextPage && !engineQuery.isFetchingNextPage) {
+      if (engineQuery.hasNextPage && !engineQuery.isFetching) {
         engineQuery.fetchNextPage();
       }
-    } else if (chainQuery.hasNextPage && !chainQuery.isFetchingNextPage) {
+    } else if (chainQuery.hasNextPage && !chainQuery.isFetching) {
       chainQuery.fetchNextPage();
     }
   };

--- a/src/screens/assetDetails/children/activitiesList.tsx
+++ b/src/screens/assetDetails/children/activitiesList.tsx
@@ -1,4 +1,11 @@
-import React, { ComponentType, JSXElementConstructor, ReactElement, useState } from 'react';
+import React, {
+  ComponentType,
+  JSXElementConstructor,
+  ReactElement,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { useIntl } from 'react-intl';
 import { SectionList, Text, RefreshControl, ActivityIndicator } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
@@ -16,6 +23,7 @@ interface ActivitiesListProps {
   completedActivities: CoinActivity[];
   refreshing: boolean;
   loading: boolean;
+  loadingMore: boolean;
   failed: boolean;
   activitiesEnabled: boolean;
   onEndReached: () => void;
@@ -26,6 +34,7 @@ interface ActivitiesListProps {
 export const ActivitiesList = ({
   header,
   loading,
+  loadingMore,
   refreshing,
   failed,
   completedActivities,
@@ -42,7 +51,10 @@ export const ActivitiesList = ({
 
   const [cancellingTrxIndex, setCancellingTrxIndex] = useState(-1);
 
-  const _onCancelPress = async (trxId: number) => {
+  // Every callback below is stable, and `Transaction` is memoised, so expanding one row or
+  // starting a cancel no longer re-renders every other mounted row. A closure built inside
+  // renderItem would defeat that on its own, so the row is handed the activity back instead.
+  const _onCancelPress = useCallback(async (trxId: number) => {
     try {
       if (trxId != null) {
         setCancellingTrxIndex(trxId);
@@ -52,47 +64,53 @@ export const ActivitiesList = ({
     } catch (err) {
       setCancellingTrxIndex(-1);
     }
-  };
+  }, []);
 
-  const _onRepeatPress = async (item: CoinActivity) => {
-    if (onActionPress) {
-      onActionPress(TransferTypes.TRANSFER, item);
-    }
-  };
+  const _onRepeatPress = useCallback(
+    (item: CoinActivity) => {
+      if (onActionPress) {
+        onActionPress(TransferTypes.TRANSFER, item);
+      }
+    },
+    [onActionPress],
+  );
 
-  const _renderActivityItem = ({ item, index }: any) => {
-    return (
+  const _renderActivityItem = useCallback(
+    ({ item, index }: any) => (
       <Transaction
         item={item}
         index={index}
         cancelling={cancellingTrxIndex === item.trxIndex}
-        onCancelPress={() => {
-          _onCancelPress(item.trxIndex);
-        }}
-        onRepeatPress={() => _onRepeatPress(item)}
+        onCancelPress={_onCancelPress}
+        onRepeatPress={_onRepeatPress}
       />
-    );
-  };
-
-  const sections = [];
+    ),
+    [cancellingTrxIndex, _onCancelPress, _onRepeatPress],
+  );
 
   // Explicit keys: without them the pending section appearing shifts the completed
   // section's identity and re-mounts every visible row.
-  if (pendingActivities && pendingActivities.length) {
-    sections.push({
-      key: 'pending',
-      title: intl.formatMessage({ id: 'wallet.pending_requests' }),
-      data: pendingActivities,
-    });
-  }
+  const sections = useMemo(() => {
+    const next = [];
 
-  if (activitiesEnabled) {
-    sections.push({
-      key: 'completed',
-      title: intl.formatMessage({ id: 'wallet.activities' }),
-      data: completedActivities || [],
-    });
-  }
+    if (pendingActivities && pendingActivities.length) {
+      next.push({
+        key: 'pending',
+        title: intl.formatMessage({ id: 'wallet.pending_requests' }),
+        data: pendingActivities,
+      });
+    }
+
+    if (activitiesEnabled) {
+      next.push({
+        key: 'completed',
+        title: intl.formatMessage({ id: 'wallet.activities' }),
+        data: completedActivities || [],
+      });
+    }
+
+    return next;
+  }, [pendingActivities, completedActivities, activitiesEnabled, intl]);
 
   const _refreshControl = (
     <RefreshControl
@@ -109,7 +127,7 @@ export const ActivitiesList = ({
   // bare header with nothing under it. Only claim "no transactions" once a request has
   // actually settled without error.
   const _renderFooter = () => {
-    if (loading) {
+    if (loading || loadingMore) {
       return (
         <ActivityIndicator
           color={EStyleSheet.value('$primaryBlue')}
@@ -146,6 +164,14 @@ export const ActivitiesList = ({
       ListFooterComponent={_renderFooter()}
       ListHeaderComponent={header}
       refreshControl={_refreshControl}
+      // A row is a fixed-height line, so a screen holds well under 15. Rendering the
+      // default 10 per batch across an unbounded window is what makes a long history
+      // stutter. `removeClippedSubviews` is deliberately not set: it is the flag with a
+      // history of blanking rows and swallowing taps on Android, and the win here does not
+      // justify that risk.
+      initialNumToRender={15}
+      maxToRenderPerBatch={10}
+      windowSize={11}
       onEndReachedThreshold={0.5}
       onEndReached={() => {
         onEndReached();

--- a/src/screens/assetDetails/children/activitiesList.tsx
+++ b/src/screens/assetDetails/children/activitiesList.tsx
@@ -3,7 +3,9 @@ import React, {
   JSXElementConstructor,
   ReactElement,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useIntl } from 'react-intl';
@@ -51,29 +53,41 @@ export const ActivitiesList = ({
 
   const [cancellingTrxIndex, setCancellingTrxIndex] = useState(-1);
 
-  // Every callback below is stable, and `Transaction` is memoised, so expanding one row or
+  // Latest-value refs, so the row callbacks below can be genuinely stable without going
+  // stale. Depending on either value directly would rebuild the callback every render and
+  // defeat the memoised row, which is the whole point of hoisting these out of renderItem:
+  // `useMutation` returns a fresh `{ ...result, mutate, mutateAsync }` object each render,
+  // and `assetDetailsScreen` rebuilds `onActionPress` each render too. Assigned in an
+  // effect rather than during render, and an event can only fire after that has run.
+  const cancelMutationRef = useRef(limitOrderCancel);
+  const onActionPressRef = useRef(onActionPress);
+
+  useEffect(() => {
+    cancelMutationRef.current = limitOrderCancel;
+    onActionPressRef.current = onActionPress;
+  });
+
+  // Both callbacks are stable and `Transaction` is memoised, so expanding one row or
   // starting a cancel no longer re-renders every other mounted row. A closure built inside
   // renderItem would defeat that on its own, so the row is handed the activity back instead.
   const _onCancelPress = useCallback(async (trxId: number) => {
+    if (trxId == null) {
+      return;
+    }
+
     try {
-      if (trxId != null) {
-        setCancellingTrxIndex(trxId);
-        await limitOrderCancel.mutateAsync({ orderId: trxId });
-        setCancellingTrxIndex(-1);
-      }
+      setCancellingTrxIndex(trxId);
+      await cancelMutationRef.current.mutateAsync({ orderId: trxId });
     } catch (err) {
+      // Swallowed deliberately: the mutation surfaces its own failure toast.
+    } finally {
       setCancellingTrxIndex(-1);
     }
   }, []);
 
-  const _onRepeatPress = useCallback(
-    (item: CoinActivity) => {
-      if (onActionPress) {
-        onActionPress(TransferTypes.TRANSFER, item);
-      }
-    },
-    [onActionPress],
-  );
+  const _onRepeatPress = useCallback((item: CoinActivity) => {
+    onActionPressRef.current?.(TransferTypes.TRANSFER, item);
+  }, []);
 
   const _renderActivityItem = useCallback(
     ({ item, index }: any) => (

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -90,8 +90,11 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
     fetchDetailsRef.current = _fetchDetails;
   });
 
+  // No fetch on mount: every query here loads itself, respecting `staleTime`. The call
+  // that used to be here fell through to `fetchNextPage`, so re-entering the screen inside
+  // the 60s window (nothing in flight, so the loading guard did not hold) appended an older
+  // page the user had not scrolled to, one extra get_account_history per screen open.
   useEffect(() => {
-    _fetchDetails();
     const appStateSub = AppState.addEventListener('change', _handleAppStateChange);
     return _cleanup(appStateSub);
   }, []);
@@ -276,6 +279,7 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
         pendingActivities={pendingRequestsQuery.data || []}
         refreshing={activitiesQuery.isRefreshing}
         loading={activitiesQuery.isLoading}
+        loadingMore={activitiesQuery.isFetchingNextPage}
         failed={activitiesQuery.isError}
         activitiesEnabled={asset.layer !== 'chain'}
         onEndReached={_fetchDetails}

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -128,6 +128,9 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
       return;
     }
 
+    // This check is only an early-out on the very first load. The concurrency guard that
+    // matters lives in `_fetchNextPage`, which gates on the query's overall `isFetching`,
+    // because `fetchNextPage` would otherwise cancel an in-flight refresh.
     activitiesQuery.fetchNextPage();
   };
 


### PR DESCRIPTION
Closes #3507

The six items from the issue, one commit's worth each, all in the wallet activity path.

**Fetch on mount.** `assetDetailsScreen` called `_fetchDetails()` on mount, which with no `refresh` flag falls through to `fetchNextPage()` unless something is in flight. On a cold open the query is fetching so it returned early, but re-entering inside the 60s `staleTime` appended an older page the user had not scrolled to: one extra `get_account_history` per screen open. Every query on that screen loads itself, so the call is gone.

**`isLoading`.** Was `isLoading || isFetching`, true for the first load, a background refetch and a next-page fetch alike. The footer showed one spinner for all three and paging was gated on whichever happened to be in flight. Now `isLoading` is the first load only, with `isFetchingNextPage` alongside it.

**Unreachable page shapes.** `_data` tolerated `{ entries }` and the `[trxIndex, { op }]` tuple. The first is the shape of `getTransactionsInfiniteQueryOptions`, which this hook stopped using in #3480; the second predates the SDK. The query key namespace is `assets`, which `_shouldDehydrateQuery` does not persist, so no page can outlive the session that fetched it and neither branch is reachable. `groomingTransactionData` keeps its own tuple handling, which is separately tested.

**Set membership** instead of rescanning a 21-entry array per history row.

**Row re-renders.** `TransactionView` is memoised, and the list hands it stable callbacks rather than closures rebuilt per row per render, so the row calls back with its own activity. Expanding one row no longer re-renders every mounted row. Added `initialNumToRender` / `maxToRenderPerBatch` / `windowSize`. `removeClippedSubviews` is deliberately **not** set: it is the flag with a history of blanking rows and swallowing taps on Android, and the win does not justify it.

**Page size 50 to 100.** `get_account_history` walks back until it has `limit` matches, so the cost is flat on an ordinary account and scales with page size where matches are sparse. Measured on api.deathwing.me with this op set:

```
             20      50     100     200     500
ecency       53ms    52ms    63ms   108ms   157ms
bulliontools 54ms    71ms   111ms   113ms   296ms
good-karma  255ms   415ms   497ms   701ms  1710ms
```

The issue originally suggested 200. 100 halves the round trips on the accounts most people have without doubling the scan for a witness account, which already sits closest to the client's 10s ceiling.

`Transaction` and `ActivitiesList` each have exactly one consumer, so the callback contract change is contained. 892 tests pass, typecheck clean.

Wants a device pass: open a token twice inside a minute and confirm only one history request; scroll to page and confirm the footer spinner appears for paging and not for a pull to refresh; expand a row in a long list and confirm nothing else redraws.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity history loading and pagination behavior.
  * Prevented unintended additional page loads when revisiting asset details.
  * Added clearer loading states for initial activity loading and loading more results.
  * Improved transaction repeat and cancel actions.

* **Performance**
  * Improved activity list rendering and scrolling performance, especially for larger histories.
  * Increased activity history page size to display more records efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->