### PR TITLE
Unclip the search filter icon and unify filter controls on tune

### DIFF
--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -302,7 +302,9 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
     <SafeAreaView edges={['top']} style={styles.container}>
       <BasicHeader
         title={intl.formatMessage({ id: 'wallet.coin_details' })}
-        rightIconName={canFilterActivities ? 'filter-list' : undefined}
+        // `tune` is the shared glyph for filter controls across the app: search filters
+        // and the wallet's manage-tokens button use the same one.
+        rightIconName={canFilterActivities ? 'tune' : undefined}
         rightIconAccessibilityLabel={intl.formatMessage({ id: 'wallet.filter_activities' })}
         iconType="MaterialIcons"
         handleRightIconPress={_onFilterPress}

--- a/src/screens/searchResult/screen/searchResultScreen.tsx
+++ b/src/screens/searchResult/screen/searchResultScreen.tsx
@@ -92,10 +92,15 @@ const SearchResultScreen = ({ navigation }: any) => {
         </View>
         <IconButton
           style={styles.filterButton}
-          iconStyle={styles.filterIcon}
+          // `tune` has no outline variant, so "some filter is set" is carried by colour
+          // rather than by swapping the glyph.
+          iconStyle={activeFilterCount > 0 ? styles.filterIconActive : styles.filterIcon}
           iconType="MaterialCommunityIcons"
-          name={activeFilterCount > 0 ? 'filter' : 'filter-outline'}
+          name="tune"
           size={22}
+          // Restores the touch target the removed padding was providing, without
+          // shrinking the content box the icon is drawn in.
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           onPress={_openFilters}
           accessibilityLabel={intl.formatMessage({ id: 'search_result.filters.open' })}
         />

--- a/src/screens/searchResult/screen/searchResultStyles.ts
+++ b/src/screens/searchResult/screen/searchResultStyles.ts
@@ -51,12 +51,18 @@ export default EStyleSheet.create({
   searchInputWrapper: {
     flex: 1,
   },
+  // ⛔ No horizontal padding here. `IconButton` is a fixed 30x30 with a border radius,
+  // which makes it clip its children on iOS, so padding shrinks the content box rather
+  // than growing the button: 8pt a side left 14pt for a 22pt glyph and sliced 4pt off
+  // each edge of the icon. Use the component's `hitSlop` to enlarge the touch target.
   filterButton: {
     marginTop: 20,
     marginRight: 12,
-    paddingHorizontal: 8,
   },
   filterIcon: {
     color: '$iconColor',
+  },
+  filterIconActive: {
+    color: '$primaryBlue',
   },
 });

--- a/src/screens/wallet/children/walletHeader.tsx
+++ b/src/screens/wallet/children/walletHeader.tsx
@@ -239,7 +239,10 @@ export const WalletHeader = ({
           >
             <Icon
               iconType="MaterialCommunityIcons"
-              name="cog"
+              // `tune` rather than a cog: this picks which tokens are shown, which is the
+              // same kind of control as the search and wallet history filters, and those
+              // now share this glyph. A cog reads as app settings.
+              name="tune"
               size={20}
               color={EStyleSheet.value('$iconColor')}
             />


### PR DESCRIPTION
Closes #3513

## The clipping

Reported from a device screenshot: the search filter button rendered as a sliced glyph, cut cleanly down both sides.

`IconButton` is a fixed box (`width: 30, height: 30, borderRadius: 15`), and the border radius makes it clip its children on iOS. The search screen added `paddingHorizontal: 8` to that fixed box, so the content width became `30 - 16 = 14pt` while the icon draws at `size={22}`. The glyph overflowed by 4pt a side and the rounded container clipped it.

The padding was standing in for a touch target. `IconButton` already supports that properly through `hitSlop`, added with a note that the button is a fixed 30x30 and below the 44pt guideline, so the fix is to use it.

⚠️ This is a shape the component invites: any call site that gives `IconButton` horizontal padding, or an icon `size` near 30, clips the same way. Only the reported one is changed here.

## The icon

`tune`, three horizontal lines with a knob on each, in all three filter controls so they read as the same kind of control:

- search filters, was `filter` / `filter-outline`
- the wallet history filter from #3512, was `filter-list`
- the wallet header's manage-tokens button, was `cog`

The cog is the one worth calling out: it picks which tokens are shown, which is a filter, while a cog reads as app settings.

`filter` / `filter-outline` encoded whether any filter was set and `tune` has no outline variant, so that state moves to colour: `$primaryBlue` when `activeFilterCount > 0`, `$iconColor` otherwise.

Wants a device pass, since this is pixels and tests cannot see it: the search icon renders whole, the active state is legible in both themes, and the button is still comfortable to hit.
