### PR TITLE
Bump version to 3.5.9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
-        versionName "3.5.8"
+        versionName "3.5.9"
         resValue "string", "build_config_package", "app.esteem.mobile.android"
         multiDexEnabled true
         // react-native-image-crop-picker

--- a/ios/Ecency.xcodeproj/project.pbxproj
+++ b/ios/Ecency.xcodeproj/project.pbxproj
@@ -1448,7 +1448,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1494,7 +1494,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1535,7 +1535,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1618,7 +1618,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;

--- a/ios/Ecency/Info.plist
+++ b/ios/Ecency/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.8</string>
+	<string>3.5.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/EcencyTests/Info.plist
+++ b/ios/EcencyTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.8</string>
+	<string>3.5.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
 </dict>
 </plist>

--- a/ios/eshare/Info.plist
+++ b/ios/eshare/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.8</string>
+	<string>3.5.9</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecency",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "displayName": "Ecency",
   "private": true,
   "rnpm": {


### PR DESCRIPTION
Opens 3.5.9 for development. 3.5.8 shipped in f36a6d4.

## How it was produced

`yarn bump-patch` cannot run to completion on Linux: it is `npm version patch`, whose `version` hook is `version-ios.sh` (macOS `PlistBuddy`) and whose `postversion` hook is `react-native-version`, which shells out to `xcode-select`.

So package.json was bumped with the script's own command and `--ignore-scripts`, `react-native-version` handled Android, and the iOS files were edited by hand to match what the previous bump did.

The resulting diff is the same file set and the same line counts as f36a6d4, the 3.5.8 bump:

```
android/app/build.gradle             | 2 +-
ios/Ecency.xcodeproj/project.pbxproj | 8 ++++----
ios/Ecency/Info.plist                | 2 +-
ios/EcencyTests/Info.plist           | 4 ++--
ios/eshare/Info.plist                | 4 ++--
package.json                         | 2 +-
```

## What changed

- `package.json` 3.5.8 to 3.5.9
- `android/app/build.gradle` `versionName`. `versionCode` is computed in `android/build.gradle` from package.json (`getNpmVersionArray`), so it follows on its own: 30508 to 30509
- `ios/Ecency/Info.plist` `CFBundleShortVersionString`. Its `CFBundleVersion` is `$(CURRENT_PROJECT_VERSION)` and is deliberately left as the variable
- `ios/EcencyTests/Info.plist` and `ios/eshare/Info.plist`, both version and build number, 33 to 34
- `ios/Ecency.xcodeproj/project.pbxproj`, all four `CURRENT_PROJECT_VERSION`, 33 to 34

Whoever next runs `yarn bump-patch` on a Mac should get an identical result; this is the same end state, reached without Xcode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **3.5.9** across Android, iOS, and package metadata.
  * Incremented the iOS build number to **34** for the main app and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->