### PR TITLE
Report store errors to Sentry by code, skip user cancellations

### DIFF
--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -291,34 +291,45 @@ class InAppPurchaseContainer extends Component<any, any> {
         AsyncStorage.removeItem(PENDING_ACCOUNT_PURCHASE_KEY).catch(() => {});
       }
 
-      const { intl, handleOnPurchaseFailure } = this.props;
-
       // A cancelled billing sheet is a breadcrumb, every other store code is its
       // own Sentry issue (see providers/iap/errors).
-      IAP.reportIapError(error, { stage: 'purchase' });
-      if (IAP.isBillingUnavailableError(error) && Platform.OS === 'android') {
-        Alert.alert(
-          intl.formatMessage({
-            id: 'alert.warning',
-          }),
-          intl.formatMessage({
-            id: 'alert.google_play_version',
-          }),
-        );
-      } else if (!IAP.isUserCancelledError(error)) {
-        console.warn('failed puchase:', error);
-        Alert.alert(
-          intl.formatMessage({
-            id: 'alert.warning',
-          }),
-          (error as any).message,
-        );
-      }
-      this.setState({ isProcessing: false });
-      if (handleOnPurchaseFailure) {
-        handleOnPurchaseFailure(error);
-      }
+      this._handlePurchaseFailure(error, IAP.reportIapError(error, { stage: 'purchase' }));
     });
+  };
+
+  // Shared by the purchase-error listener and the requestPurchase catch: the same
+  // store failure can arrive through either, or both, and neither path is
+  // guaranteed. Whichever runs first reports it and tells the user; a duplicate
+  // only makes sure the UI is no longer stuck in processing.
+  _handlePurchaseFailure = (error: any, report: IAP.IapReport) => {
+    const { intl, handleOnPurchaseFailure } = this.props;
+
+    this.setState({ isProcessing: false });
+    if (report === 'duplicate') {
+      return;
+    }
+
+    if (IAP.isBillingUnavailableError(error) && Platform.OS === 'android') {
+      Alert.alert(
+        intl.formatMessage({
+          id: 'alert.warning',
+        }),
+        intl.formatMessage({
+          id: 'alert.google_play_version',
+        }),
+      );
+    } else if (report !== 'cancelled') {
+      console.warn('failed puchase:', error);
+      Alert.alert(
+        intl.formatMessage({
+          id: 'alert.warning',
+        }),
+        error?.message,
+      );
+    }
+    if (handleOnPurchaseFailure) {
+      handleOnPurchaseFailure(error);
+    }
   };
 
   _getTitle = (title: any) => {
@@ -423,13 +434,11 @@ class InAppPurchaseContainer extends Component<any, any> {
       try {
         await IAP.requestPurchase(sku);
       } catch (err) {
-        // A store failure also reaches purchaseErrorListener, which reports it and
-        // resets the UI. Only an error that never went through the store (request
-        // validation, a programming error) is ours to report here.
-        if (!IAP.hasStoreCode(err)) {
-          this.setState({ isProcessing: false });
-          IAP.reportIapError(err, { stage: 'request', sku });
-        }
+        // Rejections range from request validation (no store code, never reaches
+        // the listener) to coded pre-flight failures such as not-prepared that may
+        // or may not also be emitted as a purchase-error event. Report and handle
+        // every one; reportIapError flags the ones the listener already took.
+        this._handlePurchaseFailure(err, IAP.reportIapError(err, { stage: 'request', sku }));
       }
     } else {
       navigation.navigate({

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -79,7 +79,7 @@ class InAppPurchaseContainer extends Component<any, any> {
       // place rest of unconsumed purhcases in state
       this._getUnconsumedPurchases();
     } catch (err) {
-      captureException(err);
+      IAP.reportIapError(err, { stage: 'init' });
       console.warn((err as any).code, (err as any).message);
 
       Alert.alert(
@@ -220,7 +220,7 @@ class InAppPurchaseContainer extends Component<any, any> {
           console.info('ackResult', ackResult);
         } catch (ackErr) {
           console.warn('finishTransaction failed (non-fatal):', ackErr);
-          captureException(ackErr);
+          IAP.reportIapError(ackErr, { stage: 'finish', sku: get(purchase, 'productId') });
         }
 
         this.setState({ isProcessing: false });
@@ -272,7 +272,7 @@ class InAppPurchaseContainer extends Component<any, any> {
         }
       }
     } catch (err) {
-      captureException(err);
+      IAP.reportIapError(err, { stage: 'recover' });
       console.warn((err as any).code, (err as any).message);
     }
   };
@@ -293,7 +293,9 @@ class InAppPurchaseContainer extends Component<any, any> {
 
       const { intl, handleOnPurchaseFailure } = this.props;
 
-      captureException(error);
+      // A cancelled billing sheet is a breadcrumb, every other store code is its
+      // own Sentry issue (see providers/iap/errors).
+      IAP.reportIapError(error, { stage: 'purchase' });
       if (IAP.isBillingUnavailableError(error) && Platform.OS === 'android') {
         Alert.alert(
           intl.formatMessage({
@@ -343,7 +345,7 @@ class InAppPurchaseContainer extends Component<any, any> {
       products.sort((a, b) => parseFloat(a.price) - parseFloat(b.price)).reverse();
       this.setState({ productList: products });
     } catch (error) {
-      captureException(error);
+      IAP.reportIapError(error, { stage: 'products' });
       Alert.alert(
         intl.formatMessage({
           id: 'alert.connection_issues',
@@ -421,9 +423,7 @@ class InAppPurchaseContainer extends Component<any, any> {
       try {
         IAP.requestPurchase(sku);
       } catch (err) {
-        captureException(err, (scope) => {
-          scope.setContext('sku', { sku });
-        });
+        IAP.reportIapError(err, { stage: 'request', sku });
       }
     } else {
       navigation.navigate({

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -421,9 +421,15 @@ class InAppPurchaseContainer extends Component<any, any> {
       }
 
       try {
-        IAP.requestPurchase(sku);
+        await IAP.requestPurchase(sku);
       } catch (err) {
-        IAP.reportIapError(err, { stage: 'request', sku });
+        // A store failure also reaches purchaseErrorListener, which reports it and
+        // resets the UI. Only an error that never went through the store (request
+        // validation, a programming error) is ours to report here.
+        if (!IAP.hasStoreCode(err)) {
+          this.setState({ isProcessing: false });
+          IAP.reportIapError(err, { stage: 'request', sku });
+        }
       }
     } else {
       navigation.navigate({

--- a/src/providers/iap/errors.test.ts
+++ b/src/providers/iap/errors.test.ts
@@ -142,7 +142,7 @@ describe('reportIapError', () => {
     expect(scope.setTag).toHaveBeenCalledWith('iap.product', '499spins');
   });
 
-  it('keeps an expo-iap rejection (Error instance with code) and still fingerprints by code', () => {
+  it('keeps an expo-iap rejection (Error with code) and still fingerprints by code', () => {
     // expo-iap's createPurchaseError: new Error(message) with the store fields attached.
     const rejection: any = new Error('Billing API version is not supported');
     rejection.name = '[expo-iap]: PurchaseError';
@@ -162,7 +162,10 @@ describe('reportIapError', () => {
     expect(scope.setTag).toHaveBeenCalledWith('iap.product', '999accounts');
     expect(scope.setContext).toHaveBeenCalledWith(
       'iap',
-      expect.objectContaining({ code: 'billing-unavailable', debugMessage: 'Billing Unavailable' }),
+      expect.objectContaining({
+        code: 'billing-unavailable',
+        debugMessage: 'Billing Unavailable',
+      }),
     );
   });
 

--- a/src/providers/iap/errors.test.ts
+++ b/src/providers/iap/errors.test.ts
@@ -142,6 +142,38 @@ describe('reportIapError', () => {
     expect(scope.setTag).toHaveBeenCalledWith('iap.product', '499spins');
   });
 
+  it('keeps an expo-iap rejection (Error instance with code) and still fingerprints by code', () => {
+    // expo-iap's createPurchaseError: new Error(message) with the store fields attached.
+    const rejection: any = new Error('Billing API version is not supported');
+    rejection.name = '[expo-iap]: PurchaseError';
+    rejection.code = 'billing-unavailable';
+    rejection.responseCode = 3;
+    rejection.debugMessage = 'Billing Unavailable';
+    rejection.platform = 'android';
+    rejection.productId = '999accounts';
+
+    reportIapError(rejection, { stage: 'init' });
+
+    const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(captured).toBe(rejection);
+    const scope = applyScope();
+    expect(scope.setFingerprint).toHaveBeenCalledWith(['iap', 'billing-unavailable']);
+    expect(scope.setTag).toHaveBeenCalledWith('iap.code', 'billing-unavailable');
+    expect(scope.setTag).toHaveBeenCalledWith('iap.product', '999accounts');
+    expect(scope.setContext).toHaveBeenCalledWith(
+      'iap',
+      expect.objectContaining({ code: 'billing-unavailable', debugMessage: 'Billing Unavailable' }),
+    );
+  });
+
+  it('treats an expo-iap cancellation rejection like the listener payload', () => {
+    const rejection: any = new Error('User cancelled the operation');
+    rejection.code = 'user-cancelled';
+    reportIapError(rejection, { stage: 'request', sku: '499spins' });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+
   it('captures a thrown Error as-is, tagged with the stage and without a store fingerprint', () => {
     const thrown = new Error('Email and username are required for 999accounts consumption');
     reportIapError(thrown, { stage: 'recover' });

--- a/src/providers/iap/errors.test.ts
+++ b/src/providers/iap/errors.test.ts
@@ -1,0 +1,149 @@
+import * as Sentry from '@sentry/react-native';
+import { isBillingUnavailableError, isUserCancelledError, reportIapError } from './errors';
+
+type ScopeMock = {
+  setTag: jest.Mock;
+  setFingerprint: jest.Mock;
+  setContext: jest.Mock;
+};
+
+const makeScope = (): ScopeMock => ({
+  setTag: jest.fn(),
+  setFingerprint: jest.fn(),
+  setContext: jest.fn(),
+});
+
+// Runs the CaptureContext callback captureException was given, like the SDK does.
+const applyScope = (): ScopeMock => {
+  const scope = makeScope();
+  const call = (Sentry.captureException as jest.Mock).mock.calls[0];
+  call[1](scope);
+  return scope;
+};
+
+const cancelled = {
+  code: 'user-cancelled',
+  debugMessage: '',
+  message: 'User cancelled the operation',
+  platform: 'android',
+  productId: '499spins',
+  subResponseCodeAndroid: 'no-applicable-sub-response-code',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('classifiers', () => {
+  it('recognise cancellation by OpenIAP code and by Play response code', () => {
+    expect(isUserCancelledError(cancelled)).toBe(true);
+    expect(isUserCancelledError({ responseCode: 1 })).toBe(true);
+    expect(isUserCancelledError({ code: 'network-error' })).toBe(false);
+    expect(isUserCancelledError(undefined)).toBe(false);
+  });
+
+  it('recognise billing unavailable by code and by Play response code', () => {
+    expect(isBillingUnavailableError({ code: 'billing-unavailable' })).toBe(true);
+    expect(isBillingUnavailableError({ responseCode: 3 })).toBe(true);
+    expect(isBillingUnavailableError(cancelled)).toBe(false);
+  });
+});
+
+describe('reportIapError', () => {
+  it('turns a user cancellation into a breadcrumb, never an exception', () => {
+    reportIapError(cancelled, { stage: 'purchase' });
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'iap',
+        level: 'info',
+        data: { stage: 'purchase', productId: '499spins' },
+      }),
+    );
+  });
+
+  it('also treats the Play response code 1 as a cancellation', () => {
+    reportIapError({ responseCode: 1, message: 'cancelled' }, { stage: 'purchase' });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('captures a store error as an IapError fingerprinted by code', () => {
+    reportIapError(
+      {
+        code: 'billing-unavailable',
+        message: 'Billing API version is not supported',
+        debugMessage: 'Play Store is blocked.',
+        platform: 'android',
+        productId: '999accounts',
+        responseCode: 3,
+      },
+      { stage: 'purchase' },
+    );
+
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.name).toBe('IapError');
+    expect(captured.message).toBe('IAP billing-unavailable: Billing API version is not supported');
+
+    const scope = applyScope();
+    expect(scope.setFingerprint).toHaveBeenCalledWith(['iap', 'billing-unavailable']);
+    expect(scope.setTag).toHaveBeenCalledWith('iap.stage', 'purchase');
+    expect(scope.setTag).toHaveBeenCalledWith('iap.code', 'billing-unavailable');
+    expect(scope.setTag).toHaveBeenCalledWith('iap.product', '999accounts');
+    expect(scope.setTag).toHaveBeenCalledWith('iap.platform', 'android');
+    expect(scope.setContext).toHaveBeenCalledWith(
+      'iap',
+      expect.objectContaining({
+        code: 'billing-unavailable',
+        debugMessage: 'Play Store is blocked.',
+        responseCode: 3,
+      }),
+    );
+  });
+
+  it('gives different store codes different fingerprints', () => {
+    reportIapError({ code: 'item-unavailable', message: 'x' }, { stage: 'request', sku: 'a' });
+    reportIapError({ code: 'developer-error', message: 'y' }, { stage: 'request', sku: 'a' });
+
+    const fingerprints = (Sentry.captureException as jest.Mock).mock.calls.map((call) => {
+      const scope = makeScope();
+      call[1](scope);
+      return scope.setFingerprint.mock.calls[0][0];
+    });
+    expect(fingerprints).toEqual([
+      ['iap', 'item-unavailable'],
+      ['iap', 'developer-error'],
+    ]);
+  });
+
+  it('falls back to the sku from context when the store error carries no productId', () => {
+    reportIapError(
+      { code: 'item-unavailable', message: 'x' },
+      { stage: 'request', sku: '499spins' },
+    );
+    const scope = applyScope();
+    expect(scope.setTag).toHaveBeenCalledWith('iap.product', '499spins');
+  });
+
+  it('captures a thrown Error as-is, tagged with the stage and without a store fingerprint', () => {
+    const thrown = new Error('Email and username are required for 999accounts consumption');
+    reportIapError(thrown, { stage: 'recover' });
+
+    const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(captured).toBe(thrown);
+    const scope = applyScope();
+    expect(scope.setTag).toHaveBeenCalledWith('iap.stage', 'recover');
+    expect(scope.setFingerprint).not.toHaveBeenCalled();
+    expect(scope.setContext).not.toHaveBeenCalled();
+  });
+
+  it('wraps a non-Error, non-store value so Sentry still gets a stack', () => {
+    reportIapError('boom', { stage: 'init' });
+    const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe('IAP init failed: boom');
+  });
+});

--- a/src/providers/iap/errors.test.ts
+++ b/src/providers/iap/errors.test.ts
@@ -4,6 +4,7 @@ import {
   isBillingUnavailableError,
   isUserCancelledError,
   reportIapError,
+  resetIapErrorDedup,
 } from './errors';
 
 type ScopeMock = {
@@ -37,6 +38,7 @@ const cancelled = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  resetIapErrorDedup();
 });
 
 describe('classifiers', () => {
@@ -65,7 +67,7 @@ describe('classifiers', () => {
 
 describe('reportIapError', () => {
   it('turns a user cancellation into a breadcrumb, never an exception', () => {
-    reportIapError(cancelled, { stage: 'purchase' });
+    expect(reportIapError(cancelled, { stage: 'purchase' })).toBe('cancelled');
 
     expect(Sentry.captureException).not.toHaveBeenCalled();
     expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
@@ -83,7 +85,7 @@ describe('reportIapError', () => {
   });
 
   it('captures a store error as an IapError fingerprinted by code', () => {
-    reportIapError(
+    const report = reportIapError(
       {
         code: 'billing-unavailable',
         message: 'Billing API version is not supported',
@@ -95,6 +97,7 @@ describe('reportIapError', () => {
       { stage: 'purchase' },
     );
 
+    expect(report).toBe('reported');
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
     expect(Sentry.captureException).toHaveBeenCalledTimes(1);
     const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
@@ -194,5 +197,60 @@ describe('reportIapError', () => {
     const [captured] = (Sentry.captureException as jest.Mock).mock.calls[0];
     expect(captured).toBeInstanceOf(Error);
     expect(captured.message).toBe('IAP init failed: boom');
+  });
+});
+
+describe('reportIapError duplicate delivery', () => {
+  const storeError = {
+    code: 'not-prepared',
+    message: 'Billing client not ready',
+    productId: '499spins',
+  };
+
+  it('reports the first arrival and flags the second within the window, in either order', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    expect(reportIapError(storeError, { stage: 'purchase' })).toBe('reported');
+    expect(reportIapError(storeError, { stage: 'request', sku: '499spins' })).toBe('duplicate');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+
+    resetIapErrorDedup();
+    jest.clearAllMocks();
+    expect(reportIapError(storeError, { stage: 'request', sku: '499spins' })).toBe('reported');
+    expect(reportIapError(storeError, { stage: 'purchase' })).toBe('duplicate');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not breadcrumb a cancellation twice', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    expect(reportIapError(cancelled, { stage: 'purchase' })).toBe('cancelled');
+    expect(reportIapError(cancelled, { stage: 'request', sku: '499spins' })).toBe('duplicate');
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports again once the window has passed', () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    reportIapError(storeError, { stage: 'purchase' });
+    now.mockReturnValue(7_000);
+    expect(reportIapError(storeError, { stage: 'purchase' })).toBe('reported');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps different products and codes apart', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    reportIapError(storeError, { stage: 'purchase' });
+    expect(reportIapError({ ...storeError, productId: '999accounts' }, { stage: 'purchase' })).toBe(
+      'reported',
+    );
+    expect(reportIapError({ ...storeError, code: 'item-unavailable' }, { stage: 'purchase' })).toBe(
+      'reported',
+    );
+    expect(Sentry.captureException).toHaveBeenCalledTimes(3);
+  });
+
+  it('never dedups errors without a store code', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const thrown = new Error('Invalid request for Google.');
+    expect(reportIapError(thrown, { stage: 'request', sku: 'a' })).toBe('reported');
+    expect(reportIapError(thrown, { stage: 'request', sku: 'a' })).toBe('reported');
   });
 });

--- a/src/providers/iap/errors.test.ts
+++ b/src/providers/iap/errors.test.ts
@@ -1,5 +1,10 @@
 import * as Sentry from '@sentry/react-native';
-import { isBillingUnavailableError, isUserCancelledError, reportIapError } from './errors';
+import {
+  hasStoreCode,
+  isBillingUnavailableError,
+  isUserCancelledError,
+  reportIapError,
+} from './errors';
 
 type ScopeMock = {
   setTag: jest.Mock;
@@ -40,6 +45,15 @@ describe('classifiers', () => {
     expect(isUserCancelledError({ responseCode: 1 })).toBe(true);
     expect(isUserCancelledError({ code: 'network-error' })).toBe(false);
     expect(isUserCancelledError(undefined)).toBe(false);
+  });
+
+  it('tell a store error (string code) from a thrown Error or a bare value', () => {
+    expect(hasStoreCode(cancelled)).toBe(true);
+    expect(hasStoreCode({ code: 'item-unavailable' })).toBe(true);
+    expect(hasStoreCode(new Error('Invalid request for Google.'))).toBe(false);
+    expect(hasStoreCode({ code: '' })).toBe(false);
+    expect(hasStoreCode('boom')).toBe(false);
+    expect(hasStoreCode(undefined)).toBe(false);
   });
 
   it('recognise billing unavailable by code and by Play response code', () => {

--- a/src/providers/iap/errors.ts
+++ b/src/providers/iap/errors.ts
@@ -48,9 +48,12 @@ const _stringOrNull = (value: unknown): string | null =>
  * Report a store error to Sentry.
  *
  * - A user cancellation is not an error: it leaves a breadcrumb and nothing else.
- * - A `PurchaseError` object becomes a real `IapError` whose message and
- *   fingerprint carry the store code, so each code is its own Sentry issue.
- * - Anything else (a thrown Error, a string) is captured as-is with the same tags.
+ * - A store error (anything with a string `code`) is fingerprinted by that code,
+ *   so each code is its own Sentry issue. expo-iap rejections are already Error
+ *   instances ("[expo-iap]: PurchaseError" with `code` attached) and are captured
+ *   as-is to keep their stack; the plain object the purchase-error event delivers
+ *   is wrapped in an `IapError` first.
+ * - Anything else (a thrown Error, a string) is captured with the stage tag only.
  */
 export const reportIapError = (error: unknown, context: IapErrorContext): void => {
   const err = error as any;
@@ -67,15 +70,14 @@ export const reportIapError = (error: unknown, context: IapErrorContext): void =
     return;
   }
 
-  const isStoreError = code !== null && !(error instanceof Error);
+  const isStoreError = code !== null;
   let toCapture: unknown = error;
-  if (isStoreError) {
-    const message = _stringOrNull(err?.message) ?? 'store error';
-    const normalized = new Error(`IAP ${code}: ${message}`);
-    normalized.name = 'IapError';
-    toCapture = normalized;
-  } else if (!(error instanceof Error)) {
-    const normalized = new Error(`IAP ${context.stage} failed: ${String(error)}`);
+  if (!(error instanceof Error)) {
+    const normalized = new Error(
+      isStoreError
+        ? `IAP ${code}: ${_stringOrNull(err?.message) ?? 'store error'}`
+        : `IAP ${context.stage} failed: ${String(error)}`,
+    );
     normalized.name = 'IapError';
     toCapture = normalized;
   }

--- a/src/providers/iap/errors.ts
+++ b/src/providers/iap/errors.ts
@@ -1,0 +1,99 @@
+import { addBreadcrumb, captureException } from '../../utils/sentryUtils';
+
+/**
+ * Store error classification and reporting.
+ *
+ * Kept free of the expo-iap import so it can be unit tested, and so the
+ * reporting rules live next to the classifiers they depend on.
+ *
+ * expo-iap delivers a plain `PurchaseError` object ({ code, message, debugMessage,
+ * productId, ... }), not an Error instance. Capturing that object directly made
+ * Sentry file every store error as one synthetic "Object captured as exception"
+ * issue (ECENCY-MOBILE-30G), 94% of which was the user closing the billing sheet,
+ * with the remaining codes hidden in the same bucket.
+ */
+
+// Play BillingResponseCode values, reported as `responseCode` on Android.
+const RESPONSE_CODE_USER_CANCELED = 1;
+const RESPONSE_CODE_BILLING_UNAVAILABLE = 3;
+
+export const isUserCancelledError = (error: any): boolean =>
+  error?.code === 'user-cancelled' || error?.responseCode === RESPONSE_CODE_USER_CANCELED;
+
+export const isBillingUnavailableError = (error: any): boolean =>
+  error?.code === 'billing-unavailable' ||
+  error?.responseCode === RESPONSE_CODE_BILLING_UNAVAILABLE;
+
+// Where in the purchase flow the error surfaced. Tagged, not fingerprinted, so the
+// same store code stays one issue wherever it happens.
+export type IapStage = 'init' | 'products' | 'request' | 'purchase' | 'finish' | 'recover';
+
+export interface IapErrorContext {
+  stage: IapStage;
+  sku?: string;
+}
+
+const _stringOrNull = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+/**
+ * Report a store error to Sentry.
+ *
+ * - A user cancellation is not an error: it leaves a breadcrumb and nothing else.
+ * - A `PurchaseError` object becomes a real `IapError` whose message and
+ *   fingerprint carry the store code, so each code is its own Sentry issue.
+ * - Anything else (a thrown Error, a string) is captured as-is with the same tags.
+ */
+export const reportIapError = (error: unknown, context: IapErrorContext): void => {
+  const err = error as any;
+  const code = _stringOrNull(err?.code);
+  const productId = _stringOrNull(err?.productId) ?? context.sku ?? null;
+
+  if (isUserCancelledError(err)) {
+    addBreadcrumb({
+      category: 'iap',
+      level: 'info',
+      message: 'user cancelled purchase',
+      data: { stage: context.stage, productId },
+    });
+    return;
+  }
+
+  const isStoreError = code !== null && !(error instanceof Error);
+  let toCapture: unknown = error;
+  if (isStoreError) {
+    const message = _stringOrNull(err?.message) ?? 'store error';
+    const normalized = new Error(`IAP ${code}: ${message}`);
+    normalized.name = 'IapError';
+    toCapture = normalized;
+  } else if (!(error instanceof Error)) {
+    const normalized = new Error(`IAP ${context.stage} failed: ${String(error)}`);
+    normalized.name = 'IapError';
+    toCapture = normalized;
+  }
+
+  captureException(toCapture, (scope) => {
+    scope.setTag('iap.stage', context.stage);
+    if (code) {
+      scope.setTag('iap.code', code);
+    }
+    if (productId) {
+      scope.setTag('iap.product', productId);
+    }
+    const platform = _stringOrNull(err?.platform);
+    if (platform) {
+      scope.setTag('iap.platform', platform);
+    }
+    if (isStoreError) {
+      scope.setFingerprint(['iap', code as string]);
+      scope.setContext('iap', {
+        code,
+        message: err?.message ?? null,
+        debugMessage: err?.debugMessage ?? null,
+        responseCode: err?.responseCode ?? null,
+        subResponseCodeAndroid: err?.subResponseCodeAndroid ?? null,
+        productId,
+      });
+    }
+  });
+};

--- a/src/providers/iap/errors.ts
+++ b/src/providers/iap/errors.ts
@@ -24,6 +24,14 @@ export const isBillingUnavailableError = (error: any): boolean =>
   error?.code === 'billing-unavailable' ||
   error?.responseCode === RESPONSE_CODE_BILLING_UNAVAILABLE;
 
+// A store (OpenIAP) error carries a string `code`; a thrown Error or a JS-side
+// validation failure does not. expo-iap delivers a store failure BOTH to
+// purchaseErrorListener and as the requestPurchase rejection, so a catch around
+// requestPurchase must leave coded errors to the listener or every failure is
+// reported twice.
+export const hasStoreCode = (error: unknown): boolean =>
+  typeof (error as any)?.code === 'string' && (error as any).code.length > 0;
+
 // Where in the purchase flow the error surfaced. Tagged, not fingerprinted, so the
 // same store code stays one issue wherever it happens.
 export type IapStage = 'init' | 'products' | 'request' | 'purchase' | 'finish' | 'recover';
@@ -46,7 +54,7 @@ const _stringOrNull = (value: unknown): string | null =>
  */
 export const reportIapError = (error: unknown, context: IapErrorContext): void => {
   const err = error as any;
-  const code = _stringOrNull(err?.code);
+  const code = hasStoreCode(err) ? (err.code as string) : null;
   const productId = _stringOrNull(err?.productId) ?? context.sku ?? null;
 
   if (isUserCancelledError(err)) {

--- a/src/providers/iap/errors.ts
+++ b/src/providers/iap/errors.ts
@@ -41,6 +41,36 @@ export interface IapErrorContext {
   sku?: string;
 }
 
+// What reportIapError did with the error, so the caller can decide whether the
+// user still needs to hear about it.
+export type IapReport = 'reported' | 'cancelled' | 'duplicate';
+
+// expo-iap can deliver one store failure twice: to purchaseErrorListener and as
+// the requestPurchase rejection (Android always does both, in that order; iOS
+// throws directly and the event depends on the OpenIAP library). Neither arrival
+// is guaranteed, so whichever comes first is reported and a second sighting of
+// the same code and product inside this window is a duplicate.
+const DUPLICATE_WINDOW_MS = 5000;
+const _recent = new Map<string, number>();
+
+const _isDuplicate = (key: string, now: number): boolean => {
+  _recent.forEach((seenAt, seenKey) => {
+    if (now - seenAt > DUPLICATE_WINDOW_MS) {
+      _recent.delete(seenKey);
+    }
+  });
+  if (_recent.has(key)) {
+    return true;
+  }
+  _recent.set(key, now);
+  return false;
+};
+
+// Test hook: clears the duplicate window between cases.
+export const resetIapErrorDedup = (): void => {
+  _recent.clear();
+};
+
 const _stringOrNull = (value: unknown): string | null =>
   typeof value === 'string' && value.length > 0 ? value : null;
 
@@ -54,11 +84,17 @@ const _stringOrNull = (value: unknown): string | null =>
  *   as-is to keep their stack; the plain object the purchase-error event delivers
  *   is wrapped in an `IapError` first.
  * - Anything else (a thrown Error, a string) is captured with the stage tag only.
+ * - A coded error seen again within DUPLICATE_WINDOW_MS for the same product is
+ *   a duplicate delivery and is neither reported nor breadcrumbed again.
  */
-export const reportIapError = (error: unknown, context: IapErrorContext): void => {
+export const reportIapError = (error: unknown, context: IapErrorContext): IapReport => {
   const err = error as any;
   const code = hasStoreCode(err) ? (err.code as string) : null;
   const productId = _stringOrNull(err?.productId) ?? context.sku ?? null;
+
+  if (code !== null && _isDuplicate(`${code}|${productId ?? ''}`, Date.now())) {
+    return 'duplicate';
+  }
 
   if (isUserCancelledError(err)) {
     addBreadcrumb({
@@ -67,7 +103,7 @@ export const reportIapError = (error: unknown, context: IapErrorContext): void =
       message: 'user cancelled purchase',
       data: { stage: context.stage, productId },
     });
-    return;
+    return 'cancelled';
   }
 
   const isStoreError = code !== null;
@@ -106,4 +142,5 @@ export const reportIapError = (error: unknown, context: IapErrorContext): void =
       });
     }
   });
+  return 'reported';
 };

--- a/src/providers/iap/index.ts
+++ b/src/providers/iap/index.ts
@@ -1,6 +1,11 @@
 import * as iap from 'expo-iap';
 
-export { isBillingUnavailableError, isUserCancelledError, reportIapError } from './errors';
+export {
+  hasStoreCode,
+  isBillingUnavailableError,
+  isUserCancelledError,
+  reportIapError,
+} from './errors';
 export type { IapErrorContext, IapStage } from './errors';
 
 /**

--- a/src/providers/iap/index.ts
+++ b/src/providers/iap/index.ts
@@ -5,8 +5,9 @@ export {
   isBillingUnavailableError,
   isUserCancelledError,
   reportIapError,
+  resetIapErrorDedup,
 } from './errors';
-export type { IapErrorContext, IapStage } from './errors';
+export type { IapErrorContext, IapReport, IapStage } from './errors';
 
 /**
  * Single entry point for store purchases.

--- a/src/providers/iap/index.ts
+++ b/src/providers/iap/index.ts
@@ -1,5 +1,8 @@
 import * as iap from 'expo-iap';
 
+export { isBillingUnavailableError, isUserCancelledError, reportIapError } from './errors';
+export type { IapErrorContext, IapStage } from './errors';
+
 /**
  * Single entry point for store purchases.
  *
@@ -38,10 +41,6 @@ export interface IapSubscription {
   remove: () => void;
 }
 
-// Play BillingResponseCode values, reported as `responseCode` on Android.
-const RESPONSE_CODE_USER_CANCELED = 1;
-const RESPONSE_CODE_BILLING_UNAVAILABLE = 3;
-
 // OpenIAP names products id/displayPrice and returns price as a number.
 const _normalizeProduct = (product: any): IapProduct => ({
   ...product,
@@ -52,13 +51,6 @@ const _normalizeProduct = (product: any): IapProduct => ({
   currency: product.currency,
   localizedPrice: product.displayPrice,
 });
-
-export const isUserCancelledError = (error: any): boolean =>
-  error?.code === 'user-cancelled' || error?.responseCode === RESPONSE_CODE_USER_CANCELED;
-
-export const isBillingUnavailableError = (error: any): boolean =>
-  error?.code === 'billing-unavailable' ||
-  error?.responseCode === RESPONSE_CODE_BILLING_UNAVAILABLE;
 
 export const initConnection = (): Promise<any> => iap.initConnection();
 

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react-native';
-import type { Scope } from '@sentry/react-native';
+import type { Breadcrumb, Scope } from '@sentry/react-native';
 
 // Sentry's CaptureContext callback form must return the scope it received;
 // these wrappers accept a plain mutator so call sites stay cast-free.
@@ -14,3 +14,5 @@ export const captureMessage = (message: string, applyScope?: (scope: Scope) => v
     applyScope?.(scope);
     return scope;
   });
+
+export const addBreadcrumb = (breadcrumb: Breadcrumb) => Sentry.addBreadcrumb(breadcrumb);


### PR DESCRIPTION
Closes #3516

Sentry ECENCY-MOBILE-30G: 92 events / 45 users since 2026-08-13. expo-iap delivers a plain `PurchaseError` object to `purchaseErrorListener`, and `captureException(error)` ran before the listener decided whether the error mattered, so every store error was filed as one synthetic "Object captured as exception" issue. 47 of the last 50 events were `user-cancelled`, 3 were `billing-unavailable`, and any real failure code would have been buried in the same bucket.

Changes
- `providers/iap/errors.ts` (new): holds `isUserCancelledError` / `isBillingUnavailableError` (moved from `index.ts`, re-exported there) plus `reportIapError(error, { stage, sku })`:
  - user cancellation (OpenIAP `user-cancelled` or Play `responseCode` 1) → breadcrumb only;
  - `PurchaseError` object → `IapError("IAP <code>: <message>")`, fingerprint `['iap', code]`, tags `iap.stage` / `iap.code` / `iap.product` / `iap.platform`, context with `debugMessage`, `responseCode`, `subResponseCodeAndroid`;
  - thrown `Error` → captured as-is with the stage tag; other values are wrapped so Sentry gets a stack.
- `inAppPurchaseContainer.tsx`: the six expo-iap call sites (init, products, request, purchase listener, finishTransaction, recovery) use `reportIapError`. The AsyncStorage and purchase-order catches are unchanged.
- `sentryUtils.ts`: `addBreadcrumb` wrapper.
- `providers/iap/errors.test.ts`: 9 tests covering the classifiers, the cancel path, fingerprint-per-code, sku fallback and the Error passthrough.

Test plan
- `jest src/providers/iap/errors.test.ts` passes; eslint and prettier clean on changed files; `node scripts/typecheck.js` ok (0 errors, baseline 0).
- After release: 30G stops receiving events; a real store failure shows up as `IapError: IAP <code>: ...` with its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and reporting of in-app purchase errors across initialization, purchasing, recovery, and transaction completion.
  * Reduced duplicate error reports while preserving relevant store and purchase details.
  * User cancellations are handled without unnecessary error reports, and purchase processing states reset correctly.
  * Added clearer error context, including purchase stage, product, platform, and store details.

* **Tests**
  * Added comprehensive coverage for error classification, deduplication, cancellation, metadata, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->