### PR TITLE
fix(newsletter): profile subscriber row layout and first-class Email digest action

### DIFF
--- a/src/components/newsletterSenderInfo/index.ts
+++ b/src/components/newsletterSenderInfo/index.ts
@@ -1,2 +1,1 @@
 export { default as NewsletterSenderInfo } from './newsletterSenderInfo';
-export { NEWSLETTER_SENDER_INFO_HEIGHT } from './newsletterSenderInfo';

--- a/src/components/newsletterSenderInfo/index.ts
+++ b/src/components/newsletterSenderInfo/index.ts
@@ -1,1 +1,2 @@
 export { default as NewsletterSenderInfo } from './newsletterSenderInfo';
+export { NEWSLETTER_SENDER_INFO_HEIGHT } from './newsletterSenderInfo';

--- a/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
+++ b/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import { useNavigation } from '@react-navigation/native';
@@ -11,18 +11,8 @@ import { useAppDispatch, useAuth } from '../../hooks';
 import { toastNotification } from '../../redux/actions/uiAction';
 import { IconButton } from '../iconButton';
 
-/**
- * Fixed row height, exported so ProfileSummaryView can report it through the
- * summary card's moreHeight channel: the CollapsibleCard measures its content
- * ONCE, so anything that appears after a query resolves must announce the
- * space it takes or it gets clipped (vision-mobile#3522).
- */
-export const NEWSLETTER_SENDER_INFO_HEIGHT = 28;
-
 interface Props {
   username: string;
-  /** Reports whether the row occupies space; stable identity expected. */
-  onVisibilityChange?: (visible: boolean) => void;
 }
 
 /**
@@ -32,7 +22,7 @@ interface Props {
  * view is gated to the list owner server-side, so this mounts only on the
  * own profile and stays silent while the lookup is unresolved or refused.
  */
-const NewsletterSenderInfo = ({ username, onVisibilityChange }: Props) => {
+const NewsletterSenderInfo = ({ username }: Props) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
@@ -43,15 +33,6 @@ const NewsletterSenderInfo = ({ username, onVisibilityChange }: Props) => {
   );
 
   const subscribers = senderQuery.data?.subscribers;
-  const visible = !!subscribers;
-
-  useEffect(() => {
-    onVisibilityChange?.(visible);
-    return () => {
-      onVisibilityChange?.(false);
-    };
-  }, [visible, onVisibilityChange]);
-
   if (!subscribers) {
     return null;
   }
@@ -77,19 +58,25 @@ const NewsletterSenderInfo = ({ username, onVisibilityChange }: Props) => {
         onPress={_handleCopyLink}
       />
       <TouchableOpacity onPress={() => navigation.navigate(ROUTES.SCREENS.EMAIL_DIGESTS)}>
-        <Text style={styles.manageText}>{intl.formatMessage({ id: 'newsletter.manage' })}</Text>
+        <Text style={styles.manageText} numberOfLines={1}>
+          {intl.formatMessage({ id: 'newsletter.manage' })}
+        </Text>
       </TouchableOpacity>
     </View>
   );
 };
 
 const styles = EStyleSheet.create({
+  // Natural (unfixed) height ON PURPOSE: the row lives OUTSIDE the summary
+  // card's one-shot height measurement, so it may grow with accessibility
+  // font scaling and its 30pt icon without clipping anything
+  // (vision-mobile#3522).
   row: {
-    height: NEWSLETTER_SENDER_INFO_HEIGHT,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 16,
+    paddingBottom: 4,
   },
   countText: {
     flexShrink: 1,
@@ -100,6 +87,7 @@ const styles = EStyleSheet.create({
     fontSize: 13,
     color: '$primaryBlue',
     marginLeft: 8,
+    maxWidth: 120,
   },
 });
 

--- a/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
+++ b/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { useIntl } from 'react-intl';
 import { useNavigation } from '@react-navigation/native';
@@ -11,8 +11,18 @@ import { useAppDispatch, useAuth } from '../../hooks';
 import { toastNotification } from '../../redux/actions/uiAction';
 import { IconButton } from '../iconButton';
 
+/**
+ * Fixed row height, exported so ProfileSummaryView can report it through the
+ * summary card's moreHeight channel: the CollapsibleCard measures its content
+ * ONCE, so anything that appears after a query resolves must announce the
+ * space it takes or it gets clipped (vision-mobile#3522).
+ */
+export const NEWSLETTER_SENDER_INFO_HEIGHT = 28;
+
 interface Props {
   username: string;
+  /** Reports whether the row occupies space; stable identity expected. */
+  onVisibilityChange?: (visible: boolean) => void;
 }
 
 /**
@@ -22,7 +32,7 @@ interface Props {
  * view is gated to the list owner server-side, so this mounts only on the
  * own profile and stays silent while the lookup is unresolved or refused.
  */
-const NewsletterSenderInfo = ({ username }: Props) => {
+const NewsletterSenderInfo = ({ username, onVisibilityChange }: Props) => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
@@ -33,6 +43,15 @@ const NewsletterSenderInfo = ({ username }: Props) => {
   );
 
   const subscribers = senderQuery.data?.subscribers;
+  const visible = !!subscribers;
+
+  useEffect(() => {
+    onVisibilityChange?.(visible);
+    return () => {
+      onVisibilityChange?.(false);
+    };
+  }, [visible, onVisibilityChange]);
+
   if (!subscribers) {
     return null;
   }
@@ -44,7 +63,7 @@ const NewsletterSenderInfo = ({ username }: Props) => {
 
   return (
     <View style={styles.row}>
-      <Text style={styles.countText}>
+      <Text style={styles.countText} numberOfLines={1}>
         {intl.formatMessage(
           { id: 'newsletter.subscriber_count' },
           { weekly: subscribers.weekly ?? 0, monthly: subscribers.monthly ?? 0 },
@@ -66,13 +85,14 @@ const NewsletterSenderInfo = ({ username }: Props) => {
 
 const styles = EStyleSheet.create({
   row: {
+    height: NEWSLETTER_SENDER_INFO_HEIGHT,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 16,
-    paddingTop: 6,
   },
   countText: {
+    flexShrink: 1,
     fontSize: 13,
     color: '$primaryDarkGray',
   },

--- a/src/components/profile/profileView.tsx
+++ b/src/components/profile/profileView.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { CollapsibleCard } from '../collapsibleCard';
 import { Header } from '../header';
 import { ProfileSummaryPlaceHolder, WalletDetailsPlaceHolder } from '../basicUIElements';
+import { NewsletterSenderInfo } from '../newsletterSenderInfo';
 import { ProfileSummary } from '../profileSummary';
 import { Wallet } from '../wallet';
 import { IconButton } from '../iconButton';
@@ -214,47 +215,58 @@ class ProfileView extends PureComponent<any, any> {
     return !isReady ? (
       <ProfileSummaryPlaceHolder />
     ) : (
-      <CollapsibleCard
-        title=""
-        defaultTitle=""
-        titleComponent={<View />}
-        isExpanded={isSummaryOpen}
-        handleOnExpanded={this._handleOnSummaryExpanded}
-        moreHeight={collapsibleMoreHeight}
-        fitContent
-        noBorder
-      >
-        <ProfileSummary
-          date={getFormatedCreatedDate(get(selectedUser, 'created'))}
-          about={about}
-          displayName={displayName}
-          reputation={reputation ? parseReputation(reputation) : ''}
-          followerCount={follows ? follows.follower_count : 0}
-          followingCount={follows ? follows.following_count : 0}
-          handleFollowUnfollowUser={handleFollowUnfollowUser}
-          handleMessage={handleMessage}
-          handleMuteUnmuteUser={handleMuteUnmuteUser}
-          handleOnFavoritePress={handleOnFavoritePress}
-          handleOnFollowsPress={handleOnFollowsPress}
-          handleReportUser={handleReportUser}
-          handleDelegateHp={handleDelegateHp}
-          handleUIChange={this._handleUIChange}
-          hoursRC={Math.ceil((100 - resourceCredits) * 0.833333) || null}
-          hoursVP={Math.ceil((100 - votingPower) * 0.833333) || null}
-          intl={intl}
-          isDarkTheme={isDarkTheme}
-          isFavorite={isFavorite}
-          isFollowing={isFollowing}
-          isLoggedIn={isLoggedIn}
-          isMuted={isMuted}
-          isOwnProfile={isOwnProfile}
-          isProfileLoading={isProfileLoading}
-          percentRC={resourceCredits}
-          percentVP={votingPower}
-          handleOnPressProfileEdit={handleOnPressProfileEdit}
-          username={username}
-        />
-      </CollapsibleCard>
+      <>
+        <CollapsibleCard
+          title=""
+          defaultTitle=""
+          titleComponent={<View />}
+          isExpanded={isSummaryOpen}
+          handleOnExpanded={this._handleOnSummaryExpanded}
+          moreHeight={collapsibleMoreHeight}
+          fitContent
+          noBorder
+        >
+          <ProfileSummary
+            date={getFormatedCreatedDate(get(selectedUser, 'created'))}
+            about={about}
+            displayName={displayName}
+            reputation={reputation ? parseReputation(reputation) : ''}
+            followerCount={follows ? follows.follower_count : 0}
+            followingCount={follows ? follows.following_count : 0}
+            handleFollowUnfollowUser={handleFollowUnfollowUser}
+            handleMessage={handleMessage}
+            handleMuteUnmuteUser={handleMuteUnmuteUser}
+            handleOnFavoritePress={handleOnFavoritePress}
+            handleOnFollowsPress={handleOnFollowsPress}
+            handleReportUser={handleReportUser}
+            handleDelegateHp={handleDelegateHp}
+            handleUIChange={this._handleUIChange}
+            hoursRC={Math.ceil((100 - resourceCredits) * 0.833333) || null}
+            hoursVP={Math.ceil((100 - votingPower) * 0.833333) || null}
+            intl={intl}
+            isDarkTheme={isDarkTheme}
+            isFavorite={isFavorite}
+            isFollowing={isFollowing}
+            isLoggedIn={isLoggedIn}
+            isMuted={isMuted}
+            isOwnProfile={isOwnProfile}
+            isProfileLoading={isProfileLoading}
+            percentRC={resourceCredits}
+            percentVP={votingPower}
+            handleOnPressProfileEdit={handleOnPressProfileEdit}
+            username={username}
+          />
+        </CollapsibleCard>
+        {/* Outside the CollapsibleCard ON PURPOSE: the card measures its content
+          ONCE, and this row appears only after the sender query resolves, so
+          inside it the row was clipped (and reserving a fixed height fought
+          font scaling and cached-data double counts). As a sibling it takes
+          natural height in normal flow; it follows the summary's collapse
+          state so a collapsed header hides it too. */}
+        {!!isOwnProfile && !!username && isSummaryOpen && (
+          <NewsletterSenderInfo username={username} />
+        )}
+      </>
     );
   };
 

--- a/src/components/profileSummary/view/profileSummaryStyles.ts
+++ b/src/components/profileSummary/view/profileSummaryStyles.ts
@@ -133,6 +133,9 @@ export default EStyleSheet.create({
     fontSize: 13,
     color: '$primaryDarkText',
   },
+  newsletterButton: {
+    marginLeft: 4,
+  },
   messageButton: {
     borderColor: '$iconColor',
     borderWidth: 1,

--- a/src/components/profileSummary/view/profileSummaryView.tsx
+++ b/src/components/profileSummary/view/profileSummaryView.tsx
@@ -24,7 +24,7 @@ import { makeCountFriendly } from '../../../utils/formatter';
 import styles from './profileSummaryStyles';
 import getWindowDimensions from '../../../utils/getWindowDimensions';
 import { SheetNames } from '../../../navigation/sheets';
-import { NewsletterSenderInfo } from '../../newsletterSenderInfo';
+import { NEWSLETTER_SENDER_INFO_HEIGHT, NewsletterSenderInfo } from '../../newsletterSenderInfo';
 
 const DEVICE_WIDTH = getWindowDimensions().width;
 
@@ -33,8 +33,29 @@ class ProfileSummaryView extends PureComponent<any, any> {
     super(props);
     this.state = {
       isShowPercentText: props.isShowPercentText,
+      senderInfoVisible: false,
     };
   }
+
+  // The summary card's moreHeight channel is single-valued, so every consumer
+  // of extra height reports through this ONE combiner: the VP/RC bars toggle
+  // and the subscriber row would otherwise overwrite each other's height and
+  // the card would clip whichever reported first (vision-mobile#3522).
+  _reportMoreHeight = () => {
+    const { handleUIChange } = this.props;
+    const { isShowPercentText, senderInfoVisible } = this.state;
+    if (handleUIChange) {
+      handleUIChange(
+        (isShowPercentText ? 30 : 0) + (senderInfoVisible ? NEWSLETTER_SENDER_INFO_HEIGHT : 0),
+      );
+    }
+  };
+
+  _handleSenderInfoVisibility = (visible: boolean) => {
+    if (this.state.senderInfoVisible !== visible) {
+      this.setState({ senderInfoVisible: visible }, this._reportMoreHeight);
+    }
+  };
 
   _handleOnPressLink = (url: any) => {
     if (url) {
@@ -277,7 +298,7 @@ class ProfileSummaryView extends PureComponent<any, any> {
 
   _renderBars = () => {
     const { isShowPercentText } = this.state;
-    const { handleUIChange, hoursRC, hoursVP, isDarkTheme, percentRC, percentVP } = this.props;
+    const { hoursRC, hoursVP, isDarkTheme, percentRC, percentVP } = this.props;
 
     const votingPowerHoursText = hoursVP && `• Full in ${hoursVP} hours`;
     const votingPowerText = `Voting power: ${percentVP}% ${votingPowerHoursText || ''}`;
@@ -288,9 +309,7 @@ class ProfileSummaryView extends PureComponent<any, any> {
       <TouchableOpacity
         style={styles.barsContainer}
         onPress={() =>
-          this.setState({ isShowPercentText: !isShowPercentText }, () => {
-            handleUIChange(!isShowPercentText ? 30 : 0);
-          })
+          this.setState({ isShowPercentText: !isShowPercentText }, this._reportMoreHeight)
         }
       >
         <PercentBar
@@ -323,7 +342,12 @@ class ProfileSummaryView extends PureComponent<any, any> {
         {this._renderIdentity()}
         {this._renderMetadata()}
         {this._renderFollowerStats()}
-        {!!isOwnProfile && !!username && <NewsletterSenderInfo username={username} />}
+        {!!isOwnProfile && !!username && (
+          <NewsletterSenderInfo
+            username={username}
+            onVisibilityChange={this._handleSenderInfoVisibility}
+          />
+        )}
         {this._renderBars()}
       </Fragment>
     );

--- a/src/components/profileSummary/view/profileSummaryView.tsx
+++ b/src/components/profileSummary/view/profileSummaryView.tsx
@@ -14,6 +14,7 @@ import DARK_COVER_IMAGE from '../../../assets/dark_cover_image.png';
 import { TextWithIcon } from '../../basicUIElements';
 import { PercentBar } from '../../percentBar';
 import { DropdownButton } from '../../dropdownButton';
+import { IconButton } from '../../iconButton';
 import { UserAvatar } from '../../userAvatar';
 import { ProBadge } from '../../proBadge';
 
@@ -39,6 +40,12 @@ class ProfileSummaryView extends PureComponent<any, any> {
     if (url) {
       Linking.openURL(url);
     }
+  };
+
+  _handleNewsletterPress = () => {
+    SheetManager.show(SheetNames.NEWSLETTER_DIGEST, {
+      payload: { type: 'creator', target: this.props.username },
+    });
   };
 
   _handleOnDropdownSelect = (index: any) => {
@@ -71,13 +78,6 @@ class ProfileSummaryView extends PureComponent<any, any> {
         if (handleReportUser) {
           handleReportUser();
         }
-        break;
-      case 4:
-        // Appended LAST on purpose: the dropdown dispatches by index, so a
-        // middle insertion would silently reroute the actions below it.
-        SheetManager.show(SheetNames.NEWSLETTER_DIGEST, {
-          payload: { type: 'creator', target: this.props.username },
-        });
         break;
       default:
         Alert.alert('Action not implemented');
@@ -137,7 +137,6 @@ class ProfileSummaryView extends PureComponent<any, any> {
         intl.formatMessage({ id: 'user.delegate' }),
         intl.formatMessage({ id: !isMuted ? 'user.mute' : 'user.unmute' }),
         intl.formatMessage({ id: 'user.report' }),
-        intl.formatMessage({ id: 'newsletter.profile_option' }),
       ];
     }
 
@@ -167,6 +166,17 @@ class ProfileSummaryView extends PureComponent<any, any> {
                   {intl.formatMessage({ id: 'profile.message' })}
                 </Text>
               </TouchableOpacity>
+
+              <IconButton
+                style={styles.newsletterButton}
+                iconType="MaterialCommunityIcons"
+                name="email-outline"
+                size={26}
+                color={EStyleSheet.value('$primaryBlue')}
+                disabled={isProfileLoading}
+                onPress={this._handleNewsletterPress}
+                accessibilityLabel={intl.formatMessage({ id: 'newsletter.profile_option' })}
+              />
 
               {isProfileLoading ? (
                 <ActivityIndicator

--- a/src/components/profileSummary/view/profileSummaryView.tsx
+++ b/src/components/profileSummary/view/profileSummaryView.tsx
@@ -24,7 +24,6 @@ import { makeCountFriendly } from '../../../utils/formatter';
 import styles from './profileSummaryStyles';
 import getWindowDimensions from '../../../utils/getWindowDimensions';
 import { SheetNames } from '../../../navigation/sheets';
-import { NEWSLETTER_SENDER_INFO_HEIGHT, NewsletterSenderInfo } from '../../newsletterSenderInfo';
 
 const DEVICE_WIDTH = getWindowDimensions().width;
 
@@ -33,29 +32,8 @@ class ProfileSummaryView extends PureComponent<any, any> {
     super(props);
     this.state = {
       isShowPercentText: props.isShowPercentText,
-      senderInfoVisible: false,
     };
   }
-
-  // The summary card's moreHeight channel is single-valued, so every consumer
-  // of extra height reports through this ONE combiner: the VP/RC bars toggle
-  // and the subscriber row would otherwise overwrite each other's height and
-  // the card would clip whichever reported first (vision-mobile#3522).
-  _reportMoreHeight = () => {
-    const { handleUIChange } = this.props;
-    const { isShowPercentText, senderInfoVisible } = this.state;
-    if (handleUIChange) {
-      handleUIChange(
-        (isShowPercentText ? 30 : 0) + (senderInfoVisible ? NEWSLETTER_SENDER_INFO_HEIGHT : 0),
-      );
-    }
-  };
-
-  _handleSenderInfoVisibility = (visible: boolean) => {
-    if (this.state.senderInfoVisible !== visible) {
-      this.setState({ senderInfoVisible: visible }, this._reportMoreHeight);
-    }
-  };
 
   _handleOnPressLink = (url: any) => {
     if (url) {
@@ -298,7 +276,7 @@ class ProfileSummaryView extends PureComponent<any, any> {
 
   _renderBars = () => {
     const { isShowPercentText } = this.state;
-    const { hoursRC, hoursVP, isDarkTheme, percentRC, percentVP } = this.props;
+    const { handleUIChange, hoursRC, hoursVP, isDarkTheme, percentRC, percentVP } = this.props;
 
     const votingPowerHoursText = hoursVP && `• Full in ${hoursVP} hours`;
     const votingPowerText = `Voting power: ${percentVP}% ${votingPowerHoursText || ''}`;
@@ -309,7 +287,9 @@ class ProfileSummaryView extends PureComponent<any, any> {
       <TouchableOpacity
         style={styles.barsContainer}
         onPress={() =>
-          this.setState({ isShowPercentText: !isShowPercentText }, this._reportMoreHeight)
+          this.setState({ isShowPercentText: !isShowPercentText }, () => {
+            handleUIChange(!isShowPercentText ? 30 : 0);
+          })
         }
       >
         <PercentBar
@@ -334,7 +314,6 @@ class ProfileSummaryView extends PureComponent<any, any> {
   };
 
   render() {
-    const { isOwnProfile, username } = this.props;
     return (
       <Fragment>
         {this._renderCoverImage()}
@@ -342,12 +321,6 @@ class ProfileSummaryView extends PureComponent<any, any> {
         {this._renderIdentity()}
         {this._renderMetadata()}
         {this._renderFollowerStats()}
-        {!!isOwnProfile && !!username && (
-          <NewsletterSenderInfo
-            username={username}
-            onVisibilityChange={this._handleSenderInfoVisibility}
-          />
-        )}
         {this._renderBars()}
       </Fragment>
     );


### PR DESCRIPTION
Closes #3522. Closes #3524. Two profile newsletter UX fixes from owner testing.

**Subscriber row clipped by the summary card (#3522)**

The own-profile subscriber row rendered inside the profile summary CollapsibleCard, which measures its content ONCE on first layout; the row appears only after the sender query resolves, so it was clipped under the tab bar. A first attempt reserved a fixed height through the card's `moreHeight` channel; review correctly killed it (28pt reservation smaller than the row's own 30pt icon, breaks under font scaling, double-counts when cached data renders before measurement). Final design: the row lives as a SIBLING below the card in normal layout flow with natural height, no height arithmetic at all, hidden together with the collapsed summary via `isSummaryOpen`. Small-device hardening: single-line shrinking count text, single-line max-width Manage label.

**Email digest as a first-class profile action (#3524)**

The website's mobile layout shows Email digest in the profile action row; the app buried it in the ••• dropdown. Now an envelope icon button sits next to Message (accessibility-labeled, disabled while the profile loads) opening the digest sheet, and the dropdown entry is removed so the action lives in one place.

Verification: `yarn typecheck` 0 errors (empty baseline), `yarn lint` 0 errors, full jest suite 927 passed.
