### PR TITLE
fix(editor): image upload stuck on Uploading..., corrupted typing, image in the wrong place

### DIFF
--- a/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
@@ -209,3 +209,27 @@ describe('applyMediaLink', () => {
     expect(result?.text).toBe('hello\n![](https://x/y.png)\n world');
   });
 });
+
+describe('selection safety', () => {
+  it('clamps a range selection that straddled the replaced placeholder', async () => {
+    // start before the placeholder, end after it: neither endpoint is shifted, so
+    // the end would otherwise point past the shortened body (Android throws on that)
+    const body = 'hello\n![](Uploading... img.jpg)\nworld';
+    const result = await run(body, { start: 2, end: 37 }, [
+      { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    expect(result).not.toBeNull();
+    const { start, end } = result!.selection;
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeLessThanOrEqual(result!.text.length);
+    expect(start).toBeLessThanOrEqual(end);
+  });
+
+  it('never returns a selection past the end of a body shortened by a failed upload', async () => {
+    const body = 'hello\n![](Uploading... img.jpg)\nworld';
+    const result = await run(body, { start: 2, end: 37 }, [
+      { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+    ]);
+    expect(result!.selection.end).toBeLessThanOrEqual(result!.text.length);
+  });
+});

--- a/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
@@ -3,7 +3,12 @@ import { MediaInsertStatus, Modes } from '../../../uploadsGalleryModal/types';
 
 // Helper: run applyMediaLink and capture what it writes back (null when it
 // decided nothing changed and skipped the write).
-const run = async (text: string, selection: { start: number; end: number }, items: any[]) => {
+const run = async (
+  text: string,
+  selection: { start: number; end: number },
+  items: any[],
+  otherPending?: string[],
+) => {
   let result: { text: string; selection: { start: number; end: number } } | null = null;
   await applyMediaLink({
     text,
@@ -12,6 +17,7 @@ const run = async (text: string, selection: { start: number; end: number }, item
       result = args;
     },
     items,
+    otherPending,
   });
   return result as { text: string; selection: { start: number; end: number } } | null;
 };
@@ -54,6 +60,27 @@ describe('applyMediaLink', () => {
       expect(result?.selection).toEqual({ start: 3, end: 3 });
     });
 
+    it('shifts a caret sitting exactly at the end of the replaced placeholder', async () => {
+      // index 31 is the character right after the placeholder's closing paren; the
+      // text from there on moves, so the caret must move with it
+      const result = await run(body, { start: 31, end: 31 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.selection).toEqual({ start: 26, end: 26 });
+    });
+
+    it('replaces a placeholder whose filename contains parentheses', async () => {
+      const result = await run('a\n![](Uploading... IMG_2024 (1).jpg)\nb', { start: 0, end: 0 }, [
+        {
+          filename: 'IMG_2024 (1).jpg',
+          url: 'https://x/y.png',
+          text: '',
+          status: MediaInsertStatus.READY,
+        },
+      ]);
+      expect(result?.text).toBe('a\n![](https://x/y.png)\nb');
+    });
+
     it('repairs a lone placeholder whose filename got mangled', async () => {
       const result = await run('a\n![](Uploading... imgXX)\nb', { start: 27, end: 27 }, [
         { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
@@ -84,6 +111,38 @@ describe('applyMediaLink', () => {
       const result = await run(body, { start: 0, end: 0 }, [
         { filename: 'a.jpg', url: 'https://x/a.png', text: '', status: MediaInsertStatus.READY },
       ]);
+      expect(result).toBeNull();
+    });
+
+    it('never repairs a lone placeholder while another upload is still in flight', async () => {
+      // b.jpg's placeholder is intact and belongs to it; a.jpg's was deleted by the
+      // user. Repairing here would put a.jpg's url in b.jpg's slot and then lose b.
+      const result = await run(
+        'a\n![](Uploading... b.jpg)\nb',
+        { start: 0, end: 0 },
+        [{ filename: 'a.jpg', url: 'https://x/a.png', text: '', status: MediaInsertStatus.READY }],
+        ['b.jpg'],
+      );
+      expect(result).toBeNull();
+    });
+
+    it('never repairs a lone placeholder when the same batch carries another upload', async () => {
+      const result = await run('a\n![](Uploading... b.jpg)\nb', { start: 27, end: 27 }, [
+        { filename: 'a.jpg', url: 'https://x/a.png', text: '', status: MediaInsertStatus.READY },
+        { filename: 'b.jpg', url: '', text: '', status: MediaInsertStatus.UPLOADING },
+      ]);
+      // a's ambiguous repair is refused: b's slot must never receive a's url
+      expect(result?.text).not.toContain('https://x/a.png');
+      expect(result?.text).toContain('![](Uploading... b.jpg)');
+    });
+
+    it('does not remove another upload’s placeholder when a failed upload lost its own', async () => {
+      const result = await run(
+        'a\n![](Uploading... b.jpg)\nb',
+        { start: 0, end: 0 },
+        [{ filename: 'a.jpg', url: '', text: '', status: MediaInsertStatus.FAILED }],
+        ['b.jpg'],
+      );
       expect(result).toBeNull();
     });
   });

--- a/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
@@ -210,6 +210,49 @@ describe('applyMediaLink', () => {
   });
 });
 
+describe('range selections', () => {
+  // 'hello\n![](Uploading... img.jpg)\nworld' — the placeholder spans [6, 31)
+  const body = 'hello\n![](Uploading... img.jpg)\nworld';
+
+  const selectedText = (r: { text: string; selection: { start: number; end: number } }) =>
+    r.text.slice(r.selection.start, r.selection.end);
+
+  it('keeps a range that spans the placeholder covering the same surviving text', async () => {
+    // start before the placeholder, end inside 'world'. The replacement is 5 chars
+    // shorter, so the end must come back by 5 — leaving it put would grow the
+    // selection over the trailing 'ld', which the next keystroke would replace.
+    const result = await run(body, { start: 2, end: 35 }, [
+      { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    expect(result?.selection).toEqual({ start: 2, end: 30 });
+    expect(selectedText(result!)).toBe('llo\n![](https://x/y.png)\nwor');
+    expect(body.slice(2, 35).endsWith('wor')).toBe(true);
+  });
+
+  it('keeps a spanning range correct when a failed upload removes the placeholder', async () => {
+    const result = await run(body, { start: 2, end: 35 }, [
+      { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+    ]);
+    expect(selectedText(result!)).toBe('llo\nwor');
+  });
+
+  it('collapses a range that sat entirely inside the placeholder', async () => {
+    const result = await run(body, { start: 12, end: 20 }, [
+      { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    expect(result?.selection.start).toBe(result?.selection.end);
+  });
+
+  it('maps a range that starts inside the placeholder and ends after it', async () => {
+    const result = await run(body, { start: 12, end: 35 }, [
+      { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    // start collapses to where the replaced span began, end shifts with the text
+    expect(result?.selection).toEqual({ start: 9, end: 30 });
+    expect(result!.selection.start).toBeLessThanOrEqual(result!.selection.end);
+  });
+});
+
 describe('selection safety', () => {
   it('clamps a range selection that straddled the replaced placeholder', async () => {
     // start before the placeholder, end after it: neither endpoint is shifted, so

--- a/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
@@ -170,19 +170,27 @@ describe('applyMediaLink', () => {
   });
 
   describe('FAILED', () => {
-    it('removes the exact placeholder and shifts a caret after it', async () => {
+    it('removes the exact placeholder and its line break, shifting a caret after it', async () => {
       const result = await run('hello\n![](Uploading... img.jpg)\nworld', { start: 37, end: 37 }, [
         { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
       ]);
-      expect(result?.text).toBe('hello\n\nworld');
-      expect(result?.selection).toEqual({ start: 12, end: 12 });
+      // no blank line left where the image was
+      expect(result?.text).toBe('hello\nworld');
+      expect(result?.selection).toEqual({ start: 11, end: 11 });
+    });
+
+    it('lands a caret that sat inside the failed placeholder at its start', async () => {
+      const result = await run('hello\n![](Uploading... img.jpg)\nworld', { start: 15, end: 15 }, [
+        { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+      ]);
+      expect(result?.selection).toEqual({ start: 6, end: 6 });
     });
 
     it('removes a lone mangled placeholder', async () => {
       const result = await run('a\n![](Uploading... imgXX)\nb', { start: 0, end: 0 }, [
         { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
       ]);
-      expect(result?.text).toBe('a\n\nb');
+      expect(result?.text).toBe('a\nb');
     });
 
     it('does nothing when no placeholder remains', async () => {

--- a/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.test.ts
@@ -1,0 +1,144 @@
+import applyMediaLink from './applyMediaLink';
+import { MediaInsertStatus, Modes } from '../../../uploadsGalleryModal/types';
+
+// Helper: run applyMediaLink and capture what it writes back (null when it
+// decided nothing changed and skipped the write).
+const run = async (text: string, selection: { start: number; end: number }, items: any[]) => {
+  let result: { text: string; selection: { start: number; end: number } } | null = null;
+  await applyMediaLink({
+    text,
+    selection,
+    setTextAndSelection: (args) => {
+      result = args;
+    },
+    items,
+  });
+  return result as { text: string; selection: { start: number; end: number } } | null;
+};
+
+describe('applyMediaLink', () => {
+  describe('UPLOADING', () => {
+    it('inserts a placeholder at the selection and moves the caret after it', async () => {
+      const result = await run('hello world', { start: 5, end: 5 }, [
+        { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.UPLOADING },
+      ]);
+      expect(result?.text).toBe('hello\n![](Uploading... img.jpg)\n world');
+      expect(result?.selection).toEqual({ start: 32, end: 32 });
+    });
+
+    it('does nothing without a filename', async () => {
+      const result = await run('hello', { start: 5, end: 5 }, [
+        { filename: '', url: '', text: '', status: MediaInsertStatus.UPLOADING },
+      ]);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('READY with a placeholder in the body', () => {
+    const body = 'hello\n![](Uploading... img.jpg)\nworld';
+
+    it('replaces the exact placeholder with the url', async () => {
+      const result = await run(body, { start: 37, end: 37 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.text).toBe('hello\n![](https://x/y.png)\nworld');
+      // caret was after the placeholder: shifted by the length difference
+      expect(result?.selection).toEqual({ start: 32, end: 32 });
+    });
+
+    it('leaves a caret before the placeholder untouched', async () => {
+      const result = await run(body, { start: 3, end: 3 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.text).toBe('hello\n![](https://x/y.png)\nworld');
+      expect(result?.selection).toEqual({ start: 3, end: 3 });
+    });
+
+    it('repairs a lone placeholder whose filename got mangled', async () => {
+      const result = await run('a\n![](Uploading... imgXX)\nb', { start: 27, end: 27 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.text).toBe('a\n![](https://x/y.png)\nb');
+    });
+
+    it('repairs a lone placeholder that gained alt text', async () => {
+      const result = await run('a\n![zz](Uploading... img.jpg2)\nb', { start: 0, end: 0 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.text).toBe('a\n![zz](https://x/y.png)\nb');
+    });
+  });
+
+  describe('READY with no recoverable placeholder', () => {
+    it('drops the insert instead of writing at the caret when it was removed', async () => {
+      // the wrong-position bug: the url used to be inserted mid-sentence at the
+      // live caret; now the insert is dropped (the upload is in the gallery)
+      const result = await run('hello world', { start: 5, end: 5 }, [
+        { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result).toBeNull();
+    });
+
+    it('drops the insert when several mangled placeholders make the target ambiguous', async () => {
+      const body = '![](Uploading... aXX)\n![](Uploading... bXX)';
+      const result = await run(body, { start: 0, end: 0 }, [
+        { filename: 'a.jpg', url: 'https://x/a.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('READY without a placeholder (deliberate insert)', () => {
+    it('inserts an image at the caret when the item has no filename (gallery tap)', async () => {
+      const result = await run('hello world', { start: 5, end: 5 }, [
+        { filename: '', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+      ]);
+      expect(result?.text).toBe('hello\n![](https://x/y.png)\n world');
+    });
+
+    it('inserts a raw url for a video embed', async () => {
+      const result = await run('hello', { start: 5, end: 5 }, [
+        {
+          filename: '',
+          url: 'https://3speak.tv/watch?v=a/b',
+          text: '',
+          status: MediaInsertStatus.READY,
+          mode: Modes.MODE_VIDEO,
+        },
+      ]);
+      expect(result?.text).toBe('hello\nhttps://3speak.tv/watch?v=a/b\n');
+    });
+  });
+
+  describe('FAILED', () => {
+    it('removes the exact placeholder and shifts a caret after it', async () => {
+      const result = await run('hello\n![](Uploading... img.jpg)\nworld', { start: 37, end: 37 }, [
+        { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+      ]);
+      expect(result?.text).toBe('hello\n\nworld');
+      expect(result?.selection).toEqual({ start: 12, end: 12 });
+    });
+
+    it('removes a lone mangled placeholder', async () => {
+      const result = await run('a\n![](Uploading... imgXX)\nb', { start: 0, end: 0 }, [
+        { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+      ]);
+      expect(result?.text).toBe('a\n\nb');
+    });
+
+    it('does nothing when no placeholder remains', async () => {
+      const result = await run('hello world', { start: 5, end: 5 }, [
+        { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.FAILED },
+      ]);
+      expect(result).toBeNull();
+    });
+  });
+
+  it('applies a batched UPLOADING + READY pair in one pass (deferred flush)', async () => {
+    const result = await run('hello world', { start: 5, end: 5 }, [
+      { filename: 'img.jpg', url: '', text: '', status: MediaInsertStatus.UPLOADING },
+      { filename: 'img.jpg', url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    expect(result?.text).toBe('hello\n![](https://x/y.png)\n world');
+  });
+});

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -105,8 +105,33 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
   };
 
   const _removeAt = (index: number, length: number) => {
-    newText = newText.slice(0, index) + newText.slice(index + length);
-    _shiftSelectionAfter(index + length, -length);
+    let start = index;
+    let end = index + length;
+    // Absorb one adjacent line break the way the draft sweep does: the insert wrote
+    // `\n![](...)\n`, so dropping only the placeholder leaves a blank line behind.
+    if (newText[end] === '\n') {
+      end += 1;
+    } else if (newText[end] === '\r' && newText[end + 1] === '\n') {
+      end += 2;
+    } else if (start > 0 && newText[start - 1] === '\n') {
+      start -= 1;
+      if (start > 0 && newText[start - 1] === '\r') {
+        start -= 1;
+      }
+    }
+
+    const removed = end - start;
+    newText = newText.slice(0, start) + newText.slice(end);
+
+    if (newSelection.start >= end) {
+      newSelection = {
+        start: Math.max(0, newSelection.start - removed),
+        end: Math.max(0, newSelection.end - removed),
+      };
+    } else if (newSelection.start > start) {
+      // the caret sat inside the failed placeholder: land it where it began
+      newSelection = { start, end: start };
+    }
   };
 
   const _removeFormatedString = (placeholder: string, filename?: string) => {

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -28,15 +28,35 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
   let newText = text;
   let newSelection = selection;
 
-  const _shiftSelectionAfter = (index: number, lengthDiff: number) => {
-    // Keep the caret in place relative to the text the user is editing: only
-    // positions at/after the edited region move.
-    if (newSelection.start >= index) {
-      newSelection = {
-        start: Math.max(0, newSelection.start + lengthDiff),
-        end: Math.max(0, newSelection.end + lengthDiff),
-      };
-    }
+  /**
+   * Carry the selection across one edit that replaced `[editStart, editEnd)` with
+   * `newLength` characters.
+   *
+   * Both endpoints are mapped INDEPENDENTLY, because a range that begins before
+   * the edit and ends after it has to keep covering the same words. Moving the two
+   * together (or, when only `start` was tested, moving neither) left the end where
+   * the old text put it, so a selection made across a placeholder grew to swallow
+   * whatever now sat in the gap — and the next keystroke replaced it.
+   *
+   * The mapping is monotonic, so `start <= end` still holds afterwards.
+   */
+  const _mapSelectionThroughEdit = (editStart: number, editEnd: number, newLength: number) => {
+    const lengthDiff = newLength - (editEnd - editStart);
+    const _mapPosition = (pos: number) => {
+      if (pos <= editStart) {
+        return pos;
+      }
+      if (pos >= editEnd) {
+        return Math.max(0, pos + lengthDiff);
+      }
+      // inside the replaced span, whose text is gone: collapse to where it began
+      return editStart;
+    };
+
+    newSelection = {
+      start: _mapPosition(newSelection.start),
+      end: _mapPosition(newSelection.end),
+    };
   };
 
   const _insertFormatedString = (altText: any, value: any, mode?: any) => {
@@ -59,9 +79,7 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
 
     const replaceIndex = newText.indexOf(replaceStr);
     newText = newText.replace(replaceStr, `(${url})`);
-    // Shift from the first character AFTER the replaced span: a caret sitting
-    // exactly there moves with the text that follows it.
-    _shiftSelectionAfter(replaceIndex + replaceStr.length, url.length - placeholder.length);
+    _mapSelectionThroughEdit(replaceIndex, replaceIndex + replaceStr.length, url.length + 2);
   };
 
   // Every filename that could own a placeholder in this body besides `filename`:
@@ -91,7 +109,7 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
     const start = (match.index as number) + parenIndex;
     const oldLength = match[0].length - parenIndex;
     newText = `${newText.slice(0, start)}(${url})${newText.slice(start + oldLength)}`;
-    _shiftSelectionAfter(start + oldLength, url.length + 2 - oldLength);
+    _mapSelectionThroughEdit(start, start + oldLength, url.length + 2);
   };
 
   const _removeAt = (index: number, length: number) => {
@@ -110,18 +128,8 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
       }
     }
 
-    const removed = end - start;
     newText = newText.slice(0, start) + newText.slice(end);
-
-    if (newSelection.start >= end) {
-      newSelection = {
-        start: Math.max(0, newSelection.start - removed),
-        end: Math.max(0, newSelection.end - removed),
-      };
-    } else if (newSelection.start > start) {
-      // the caret sat inside the failed placeholder: land it where it began
-      newSelection = { start, end: start };
-    }
+    _mapSelectionThroughEdit(start, end, 0);
   };
 
   const _removeFormatedString = (placeholder: string, filename?: string) => {

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -4,6 +4,10 @@ import {
   MediaInsertStatus,
   Modes,
 } from '../../../uploadsGalleryModal/types';
+import {
+  uploadPlaceholderPattern,
+  uploadPlaceholderPrefix,
+} from '../../../uploadsGalleryModal/uploadPlaceholder';
 import { replaceBetween } from './utils';
 
 interface Selection {
@@ -19,20 +23,6 @@ interface Args extends MediaInsertContext {
 }
 
 const imagePrefix = '!';
-
-export const uploadPlaceholderPrefix = 'Uploading... ';
-
-// Any upload placeholder this editor may have written: `![alt](Uploading... name)`.
-// Used to recover a placeholder whose filename got mangled (by the typing race or a
-// stray edit) and to sweep orphans out of restored drafts.
-//
-// The filename part allows one level of balanced parentheses, because gallery
-// filenames routinely contain them (`IMG_2024 (1).jpg`); stopping at the first `)`
-// matched only a prefix and left `.jpg)` behind as garbage. Alt text and filename
-// both exclude newlines so a match can never swallow surrounding body text, and the
-// alternation cannot run past the placeholder's own closing paren.
-export const uploadPlaceholderPattern = () =>
-  /!\[[^\]\n]*\]\(Uploading\.\.\.(?:[^()\n]|\([^()\n]*\))*\)/g;
 
 export default async ({ text, selection, setTextAndSelection, items, otherPending }: Args) => {
   let newText = text;

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -1,8 +1,4 @@
-import {
-  MediaInsertData,
-  MediaInsertStatus,
-  Modes,
-} from '../../../uploadsGalleryModal/container/uploadsGalleryModal';
+import { MediaInsertData, MediaInsertStatus, Modes } from '../../../uploadsGalleryModal/types';
 import { replaceBetween } from './utils';
 
 interface Selection {
@@ -17,23 +13,35 @@ interface Args {
   items: MediaInsertData[];
 }
 
+const imagePrefix = '!';
+
+export const uploadPlaceholderPrefix = 'Uploading... ';
+
+// Any upload placeholder this editor may have written: `![alt](Uploading... name)`.
+// Used to recover a placeholder whose filename got mangled (by the typing race or a
+// stray edit) and to sweep orphans out of restored drafts. Alt and filename exclude
+// newlines so the match can never swallow surrounding body text.
+export const uploadPlaceholderPattern = () => /!\[[^\]\n]*\]\(Uploading\.\.\.[^)\n]*\)/g;
+
 export default async ({ text, selection, setTextAndSelection, items }: Args) => {
-  // TODO: check if placeholder already present in text body
-  // check if cursor position is after or before media position
-  // replace placeholder with url or failure message
-  // calclulate change of cursor position
-
-  const imagePrefix = '!';
-
-  const placeholderPrefix = 'Uploading... ';
-
   let newText = text;
   let newSelection = selection;
 
-  const _insertFormatedString = (text: any, value: any, mode?: any) => {
+  const _shiftSelectionAfter = (index: number, lengthDiff: number) => {
+    // Keep the caret in place relative to the text the user is editing: only
+    // positions at/after the edited region move.
+    if (newSelection.start >= index) {
+      newSelection = {
+        start: Math.max(0, newSelection.start + lengthDiff),
+        end: Math.max(0, newSelection.end + lengthDiff),
+      };
+    }
+  };
+
+  const _insertFormatedString = (altText: any, value: any, mode?: any) => {
     // Video embeds: insert raw URL so the post renderer detects the 3Speak embed
     const formatedText =
-      mode === Modes.MODE_VIDEO ? `\n${value}\n` : `\n${imagePrefix}[${text}](${value})\n`;
+      mode === Modes.MODE_VIDEO ? `\n${value}\n` : `\n${imagePrefix}[${altText}](${value})\n`;
     newText = replaceBetween(newText, newSelection, formatedText);
     // Video inserts raw URL (\n{url}\n) so offset is 1; image wraps in ()  so offset is 2
     const cursorOffset = mode === Modes.MODE_VIDEO ? 1 : 2;
@@ -48,33 +56,50 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
   const _replaceFormatedString = (placeholder: string, url: string) => {
     const replaceStr = `(${placeholder})`;
 
-    const endingIndex = newText.indexOf(replaceStr) + replaceStr.length + 1;
+    const replaceIndex = newText.indexOf(replaceStr);
     newText = newText.replace(replaceStr, `(${url})`);
-
-    if (newSelection.start >= endingIndex) {
-      const lengthDiff = url.length - placeholder.length;
-      newSelection = {
-        start: newSelection.start + lengthDiff,
-        end: newSelection.end + lengthDiff,
-      };
-    }
+    _shiftSelectionAfter(replaceIndex + replaceStr.length + 1, url.length - placeholder.length);
   };
 
-  const _removeFormatedString = (placeholder: any) => {
+  // The exact placeholder is gone (the user edited it, or a stray keystroke landed
+  // inside it). If exactly one upload placeholder remains in the body it can only be
+  // this upload's, so repair it in place. With zero or several candidates the target
+  // is unknowable: drop the insert rather than writing at the live caret, which lands
+  // the image mid-sentence wherever the user happens to be typing. The upload itself
+  // is safe in the uploads gallery either way.
+  const _findLonePlaceholder = () => {
+    const matches = [...newText.matchAll(uploadPlaceholderPattern())];
+    return matches.length === 1 ? matches[0] : undefined;
+  };
+
+  const _replaceLonePlaceholder = (match: RegExpMatchArray, url: string) => {
+    const parenIndex = match[0].indexOf('](') + 1;
+    const start = (match.index as number) + parenIndex;
+    const oldLength = match[0].length - parenIndex;
+    newText = `${newText.slice(0, start)}(${url})${newText.slice(start + oldLength)}`;
+    _shiftSelectionAfter(start + oldLength, url.length + 2 - oldLength);
+  };
+
+  const _removeAt = (index: number, length: number) => {
+    newText = newText.slice(0, index) + newText.slice(index + length);
+    _shiftSelectionAfter(index + length, -length);
+  };
+
+  const _removeFormatedString = (placeholder: string) => {
     const formatedText = `${imagePrefix}[](${placeholder})`;
     const formatedTextIndex = newText.indexOf(formatedText);
-    newText = newText.replace(formatedText, '');
-
-    if (newSelection.start > formatedTextIndex) {
-      newSelection = {
-        start: newSelection.start - formatedText.length,
-        end: newSelection.end - formatedText.length,
-      };
+    if (formatedTextIndex >= 0) {
+      _removeAt(formatedTextIndex, formatedText.length);
+      return;
+    }
+    const lone = _findLonePlaceholder();
+    if (lone) {
+      _removeAt(lone.index as number, lone[0].length);
     }
   };
 
   items.forEach((item) => {
-    const _placeholder = item.filename && `${placeholderPrefix}${item.filename}`;
+    const _placeholder = item.filename && `${uploadPlaceholderPrefix}${item.filename}`;
 
     switch (item.status) {
       case MediaInsertStatus.UPLOADING: // means only filename is available
@@ -83,16 +108,29 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
         break;
 
       case MediaInsertStatus.READY: // means url is ready but filename may be available
-        if (_placeholder && newText.includes(_placeholder)) {
-          // means placeholder is preset is needs replacing
-          _replaceFormatedString(_placeholder, item.url);
+        if (_placeholder) {
+          // guard on the parenthesized form _replaceFormatedString actually swaps:
+          // a bare-substring check passes on e.g. `(Uploading... img.jpg2)` whose
+          // replace would then silently no-op
+          if (newText.includes(`(${_placeholder})`)) {
+            _replaceFormatedString(_placeholder, item.url);
+          } else if (item.url) {
+            const lone = _findLonePlaceholder();
+            if (lone) {
+              _replaceLonePlaceholder(lone, item.url);
+            }
+            // no recoverable placeholder: the user removed it, or it is beyond
+            // repair — deliberately no insert (see _findLonePlaceholder)
+          }
         } else if (item.url) {
+          // no placeholder was ever written (gallery tap, video embed): a
+          // deliberate insert at the caret
           _insertFormatedString(item.text, item.url, item.mode);
         }
         break;
 
       case MediaInsertStatus.FAILED: // filename available but upload failed
-        if (_placeholder && newText.includes(_placeholder)) {
+        if (_placeholder) {
           _removeFormatedString(_placeholder);
         }
         break;
@@ -104,6 +142,13 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
         break;
     }
   });
+
+  // Nothing changed (every item was dropped): skip the write. Rewriting the whole
+  // native text is exactly the operation that races with typing, so it is never
+  // done gratuitously.
+  if (newText === text && newSelection === selection) {
+    return;
+  }
 
   setTextAndSelection({ text: newText, selection: newSelection });
 };

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -189,5 +189,19 @@ export default async ({ text, selection, setTextAndSelection, items, otherPendin
     return;
   }
 
-  setTextAndSelection({ text: newText, selection: newSelection });
+  // Never hand the native input an out-of-range selection. The shifts above move
+  // both endpoints together, so a RANGE selection that straddled an edited
+  // placeholder (start before it, end after it) keeps an end that the shortened
+  // body no longer has — and on Android setting a selection past the text length
+  // throws rather than clamping.
+  const _clamped = {
+    start: Math.min(Math.max(0, newSelection.start), newText.length),
+    end: Math.min(Math.max(0, newSelection.end), newText.length),
+  };
+
+  setTextAndSelection({
+    text: newText,
+    selection:
+      _clamped.end < _clamped.start ? { start: _clamped.start, end: _clamped.start } : _clamped,
+  });
 };

--- a/src/components/markdownEditor/children/formats/applyMediaLink.ts
+++ b/src/components/markdownEditor/children/formats/applyMediaLink.ts
@@ -1,4 +1,9 @@
-import { MediaInsertData, MediaInsertStatus, Modes } from '../../../uploadsGalleryModal/types';
+import {
+  MediaInsertContext,
+  MediaInsertData,
+  MediaInsertStatus,
+  Modes,
+} from '../../../uploadsGalleryModal/types';
 import { replaceBetween } from './utils';
 
 interface Selection {
@@ -6,7 +11,7 @@ interface Selection {
   end: number;
 }
 
-interface Args {
+interface Args extends MediaInsertContext {
   text: string;
   selection: Selection;
   setTextAndSelection: (args: { selection: Selection; text: string }) => void;
@@ -19,11 +24,17 @@ export const uploadPlaceholderPrefix = 'Uploading... ';
 
 // Any upload placeholder this editor may have written: `![alt](Uploading... name)`.
 // Used to recover a placeholder whose filename got mangled (by the typing race or a
-// stray edit) and to sweep orphans out of restored drafts. Alt and filename exclude
-// newlines so the match can never swallow surrounding body text.
-export const uploadPlaceholderPattern = () => /!\[[^\]\n]*\]\(Uploading\.\.\.[^)\n]*\)/g;
+// stray edit) and to sweep orphans out of restored drafts.
+//
+// The filename part allows one level of balanced parentheses, because gallery
+// filenames routinely contain them (`IMG_2024 (1).jpg`); stopping at the first `)`
+// matched only a prefix and left `.jpg)` behind as garbage. Alt text and filename
+// both exclude newlines so a match can never swallow surrounding body text, and the
+// alternation cannot run past the placeholder's own closing paren.
+export const uploadPlaceholderPattern = () =>
+  /!\[[^\]\n]*\]\(Uploading\.\.\.(?:[^()\n]|\([^()\n]*\))*\)/g;
 
-export default async ({ text, selection, setTextAndSelection, items }: Args) => {
+export default async ({ text, selection, setTextAndSelection, items, otherPending }: Args) => {
   let newText = text;
   let newSelection = selection;
 
@@ -58,16 +69,29 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
 
     const replaceIndex = newText.indexOf(replaceStr);
     newText = newText.replace(replaceStr, `(${url})`);
-    _shiftSelectionAfter(replaceIndex + replaceStr.length + 1, url.length - placeholder.length);
+    // Shift from the first character AFTER the replaced span: a caret sitting
+    // exactly there moves with the text that follows it.
+    _shiftSelectionAfter(replaceIndex + replaceStr.length, url.length - placeholder.length);
   };
 
+  // Every filename that could own a placeholder in this body besides `filename`:
+  // other items in this batch (multi-select) plus uploads the gallery reports as
+  // still in flight from an earlier batch.
+  const _hasRivalUpload = (filename?: string) =>
+    items.some((other) => !!other.filename && other.filename !== filename) ||
+    (otherPending ?? []).some((name) => name !== filename);
+
   // The exact placeholder is gone (the user edited it, or a stray keystroke landed
-  // inside it). If exactly one upload placeholder remains in the body it can only be
-  // this upload's, so repair it in place. With zero or several candidates the target
-  // is unknowable: drop the insert rather than writing at the live caret, which lands
-  // the image mid-sentence wherever the user happens to be typing. The upload itself
-  // is safe in the uploads gallery either way.
-  const _findLonePlaceholder = () => {
+  // inside it). If exactly one upload placeholder remains in the body, and no other
+  // upload could own it, it can only be this upload's — so repair it in place. With
+  // zero or several candidates, or any rival upload in flight, the target is
+  // unknowable: drop the insert rather than writing at the live caret (which lands
+  // the image mid-sentence wherever the user happens to be typing) or into another
+  // image's slot. The upload itself is safe in the uploads gallery either way.
+  const _findLonePlaceholder = (filename?: string) => {
+    if (_hasRivalUpload(filename)) {
+      return undefined;
+    }
     const matches = [...newText.matchAll(uploadPlaceholderPattern())];
     return matches.length === 1 ? matches[0] : undefined;
   };
@@ -85,14 +109,14 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
     _shiftSelectionAfter(index + length, -length);
   };
 
-  const _removeFormatedString = (placeholder: string) => {
+  const _removeFormatedString = (placeholder: string, filename?: string) => {
     const formatedText = `${imagePrefix}[](${placeholder})`;
     const formatedTextIndex = newText.indexOf(formatedText);
     if (formatedTextIndex >= 0) {
       _removeAt(formatedTextIndex, formatedText.length);
       return;
     }
-    const lone = _findLonePlaceholder();
+    const lone = _findLonePlaceholder(filename);
     if (lone) {
       _removeAt(lone.index as number, lone[0].length);
     }
@@ -115,7 +139,7 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
           if (newText.includes(`(${_placeholder})`)) {
             _replaceFormatedString(_placeholder, item.url);
           } else if (item.url) {
-            const lone = _findLonePlaceholder();
+            const lone = _findLonePlaceholder(item.filename);
             if (lone) {
               _replaceLonePlaceholder(lone, item.url);
             }
@@ -131,7 +155,7 @@ export default async ({ text, selection, setTextAndSelection, items }: Args) => 
 
       case MediaInsertStatus.FAILED: // filename available but upload failed
         if (_placeholder) {
-          _removeFormatedString(_placeholder);
+          _removeFormatedString(_placeholder, item.filename);
         }
         break;
 

--- a/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.test.ts
+++ b/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.test.ts
@@ -31,6 +31,33 @@ describe('sweepUploadingPlaceholders', () => {
     expect(text).toBe('a\nb');
   });
 
+  it('strips a placeholder whose filename contains parentheses, leaving no garbage', () => {
+    const { text } = sweepUploadingPlaceholders('hi\n![](Uploading... IMG_2024 (1).jpg)\nbye');
+    expect(text).toBe('hi\nbye');
+  });
+
+  it('absorbs a CRLF line break without leaving a stray carriage return', () => {
+    const { text } = sweepUploadingPlaceholders('hi\r\n![](Uploading... img.jpg)\r\nbye');
+    expect(text).toBe('hi\r\nbye');
+  });
+
+  it('absorbs the TRAILING CRLF when the placeholder starts the body', () => {
+    // no preceding newline to absorb here, so the trailing branch is the only one
+    // that can keep a bare \r\n from being left behind
+    const { text } = sweepUploadingPlaceholders('![](Uploading... img.jpg)\r\nbye');
+    expect(text).toBe('bye');
+  });
+
+  it('absorbs the LEADING CRLF when the placeholder ends the body', () => {
+    const { text } = sweepUploadingPlaceholders('hi\r\n![](Uploading... img.jpg)');
+    expect(text).toBe('hi');
+  });
+
+  it('does not swallow text that follows a placeholder on the same line', () => {
+    const { text } = sweepUploadingPlaceholders('![](Uploading... img.jpg) see (this) too');
+    expect(text).toBe(' see (this) too');
+  });
+
   it('strips several placeholders, including adjacent ones, without eating body text', () => {
     const body = 'a\n![](Uploading... 1.jpg)\n![](Uploading... 2.jpg)\nb';
     const { text } = sweepUploadingPlaceholders(body);

--- a/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.test.ts
+++ b/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.test.ts
@@ -1,0 +1,67 @@
+import { sweepUploadingPlaceholders } from './sweepUploadingPlaceholders';
+
+describe('sweepUploadingPlaceholders', () => {
+  it('returns the body unchanged when it holds no placeholder', () => {
+    const body = 'hello\n![alt](https://images.ecency.com/x.png)\nworld';
+    expect(sweepUploadingPlaceholders(body, 7)).toEqual({ text: body, caret: 7 });
+  });
+
+  it('does not touch prose that merely mentions Uploading...', () => {
+    const body = 'the app said (Uploading... img.jpg) forever';
+    expect(sweepUploadingPlaceholders(body).text).toBe(body);
+  });
+
+  it('strips a placeholder and absorbs one trailing newline', () => {
+    const { text } = sweepUploadingPlaceholders('hello\n![](Uploading... img.jpg)\nworld');
+    expect(text).toBe('hello\nworld');
+  });
+
+  it('strips a placeholder at the start of the body', () => {
+    const { text } = sweepUploadingPlaceholders('![](Uploading... img.jpg)\nhello');
+    expect(text).toBe('hello');
+  });
+
+  it('strips a placeholder at the end of the body, absorbing the leading newline', () => {
+    const { text } = sweepUploadingPlaceholders('hello\n![](Uploading... img.jpg)');
+    expect(text).toBe('hello');
+  });
+
+  it('strips placeholders with alt text and mangled filenames', () => {
+    const { text } = sweepUploadingPlaceholders('a\n![zz](Uploading... imXX)\nb');
+    expect(text).toBe('a\nb');
+  });
+
+  it('strips several placeholders, including adjacent ones, without eating body text', () => {
+    const body = 'a\n![](Uploading... 1.jpg)\n![](Uploading... 2.jpg)\nb';
+    const { text } = sweepUploadingPlaceholders(body);
+    expect(text).toBe('a\nb');
+  });
+
+  it('keeps real images that sit next to a placeholder', () => {
+    const body = '![ok](https://x/y.png)\n![](Uploading... img.jpg)\ndone';
+    const { text } = sweepUploadingPlaceholders(body);
+    expect(text).toBe('![ok](https://x/y.png)\ndone');
+  });
+
+  describe('caret adjustment', () => {
+    const body = 'hello\n![](Uploading... img.jpg)\nworld';
+    // removal spans '![](Uploading... img.jpg)\n' -> indices 6..32
+
+    it('keeps a caret before the placeholder in place', () => {
+      expect(sweepUploadingPlaceholders(body, 3).caret).toBe(3);
+    });
+
+    it('shifts a caret after the placeholder back by the removed length', () => {
+      // caret at the very end (37) -> swept length (11)
+      expect(sweepUploadingPlaceholders(body, 37).caret).toBe(11);
+    });
+
+    it('lands a caret that sat inside the placeholder at the removal start', () => {
+      expect(sweepUploadingPlaceholders(body, 15).caret).toBe(6);
+    });
+
+    it('passes an undefined caret through', () => {
+      expect(sweepUploadingPlaceholders(body).caret).toBeUndefined();
+    });
+  });
+});

--- a/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
+++ b/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
@@ -1,4 +1,4 @@
-import { uploadPlaceholderPattern } from './applyMediaLink';
+import { uploadPlaceholderPattern } from '../../../uploadsGalleryModal/uploadPlaceholder';
 
 /**
  * Strip orphaned `![...](Uploading... filename)` placeholders from a body that is

--- a/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
+++ b/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
@@ -1,0 +1,73 @@
+import { uploadPlaceholderPattern } from './applyMediaLink';
+
+/**
+ * Strip orphaned `![...](Uploading... filename)` placeholders from a body that is
+ * being loaded into the editor. At load time no upload can still be in flight for
+ * this body, so any placeholder left in it is dead: its upload either failed
+ * silently or finished after the editor had closed (the file is in the uploads
+ * gallery either way). Left alone it renders as a broken image stuck on
+ * "Uploading..." forever.
+ *
+ * One newline adjacent to each removed placeholder is absorbed (the insert wrote
+ * `\n![](...)\n`), so the removal doesn't leave a blank line behind.
+ *
+ * `caret` is a saved caret position for the same body; it is shifted by the
+ * removals before it so the user still resumes at the text they were editing.
+ * Kept dependency-free so it can be unit-tested without the editor module graph.
+ */
+export const sweepUploadingPlaceholders = (
+  text: string,
+  caret?: number,
+): { text: string; caret?: number } => {
+  if (!text || !text.includes('(Uploading...')) {
+    return { text, caret };
+  }
+
+  const removals: Array<{ start: number; end: number }> = [];
+  const pattern = uploadPlaceholderPattern();
+  let match = pattern.exec(text);
+  while (match !== null) {
+    let start = match.index;
+    let end = start + match[0].length;
+    if (text[end] === '\n') {
+      end += 1;
+    } else if (start > 0 && text[start - 1] === '\n') {
+      start -= 1;
+    }
+    const prev = removals[removals.length - 1];
+    if (prev && start < prev.end) {
+      // the absorbed leading newline was already consumed by the previous removal
+      start = match.index;
+    }
+    removals.push({ start, end });
+    match = pattern.exec(text);
+  }
+
+  if (removals.length === 0) {
+    return { text, caret };
+  }
+
+  let swept = '';
+  let cursor = 0;
+  removals.forEach(({ start, end }) => {
+    swept += text.slice(cursor, start);
+    cursor = end;
+  });
+  swept += text.slice(cursor);
+
+  let newCaret = caret;
+  if (typeof caret === 'number') {
+    let shift = 0;
+    removals.forEach(({ start, end }) => {
+      if (caret >= end) {
+        shift += end - start;
+      } else if (caret > start) {
+        // caret sat inside the removed span: land it where the span began
+        shift += caret - start;
+      }
+    });
+    newCaret = caret - shift;
+  }
+
+  return { text: swept, caret: newCaret };
+};

--- a/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
+++ b/src/components/markdownEditor/children/formats/sweepUploadingPlaceholders.ts
@@ -29,10 +29,17 @@ export const sweepUploadingPlaceholders = (
   while (match !== null) {
     let start = match.index;
     let end = start + match[0].length;
+    // Absorb one adjacent line break, CRLF included, so removing the placeholder
+    // the insert wrote as `\n![](...)\n` doesn't leave a blank line (or a bare \r).
     if (text[end] === '\n') {
       end += 1;
+    } else if (text[end] === '\r' && text[end + 1] === '\n') {
+      end += 2;
     } else if (start > 0 && text[start - 1] === '\n') {
       start -= 1;
+      if (start > 0 && text[start - 1] === '\r') {
+        start -= 1;
+      }
     }
     const prev = removals[removals.length - 1];
     if (prev && start < prev.end) {

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -34,7 +34,10 @@ import { selectIsDarkTheme } from '../../../redux/selectors';
 import { walkthrough } from '../../../redux/constants/walkthroughConstants';
 import { OptionsModal } from '../../atoms';
 import { MainButton } from '../../mainButton';
-import { MediaInsertData } from '../../uploadsGalleryModal/container/uploadsGalleryModal';
+import {
+  MediaInsertContext,
+  MediaInsertData,
+} from '../../uploadsGalleryModal/container/uploadsGalleryModal';
 import { EditorToolbar } from '../children/editorToolbar';
 import applySnippet from '../children/formats/applySnippet';
 import styles from '../styles/markdownEditorStyles';
@@ -176,6 +179,14 @@ const MarkdownEditorView = ({
       // under this draft's key: on a no-caret draft that resurfaces prepend-on-type
       // next open, and on a saved-caret draft it clobbers the position being resumed.
       _persistCaret.cancel();
+      // A sweep shortened the body, so the stored caret now points past the text it
+      // belonged to. Rewrite it to the shifted position (only when one was actually
+      // saved — persisting the no-caret fallback of 0 is what the cancel above
+      // guards against). Without this, closing the draft untouched would resume at
+      // the stale offset on the next open.
+      if (hasSavedCaret && swept.text !== draftBody) {
+        dispatch(setDraftCaret(caretKeyRef.current, caret));
+      }
       // Opening a post/draft with no saved caret intentionally lands at position 0.
       // Do NOT keep an active cursor there: an auto-focused caret at 0 would prepend
       // on the next keystroke (the concern that reverted the previous fix) and the
@@ -380,13 +391,14 @@ const MarkdownEditorView = ({
     setIsSnippetsOpen(false);
   };
 
-  const _handleMediaInsert = (mediaArray: MediaInsertData[]) => {
+  const _handleMediaInsert = (mediaArray: MediaInsertData[], context?: MediaInsertContext) => {
     if (mediaArray.length) {
       applyMediaLink({
         text: bodyTextRef.current,
         selection: bodySelectionRef.current,
         setTextAndSelection: _setTextAndSelection,
         items: mediaArray,
+        otherPending: context?.otherPending,
       });
     }
   };

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -38,6 +38,7 @@ import {
   MediaInsertContext,
   MediaInsertData,
 } from '../../uploadsGalleryModal/container/uploadsGalleryModal';
+import { registerPendingFlush } from '../../uploadsGalleryModal/mediaInsertQueue';
 import { EditorToolbar } from '../children/editorToolbar';
 import applySnippet from '../children/formats/applySnippet';
 import styles from '../styles/markdownEditorStyles';
@@ -335,6 +336,18 @@ const MarkdownEditorView = ({
     [_persistCaret, _debouncedOnTextChange],
   );
 
+  // Let the screen commit the last keystrokes before it saves on the way out. The
+  // cleanup above runs after the screen's `componentWillUnmount`, so on its own it
+  // flushes typing from the debounce window too late for that save to see it.
+  useEffect(
+    () =>
+      registerPendingFlush(() => {
+        _persistCaret.flush();
+        _debouncedOnTextChange.flush();
+      }),
+    [_persistCaret, _debouncedOnTextChange],
+  );
+
   const _handleOnSelectionChange = async (event: any) => {
     const { selection } = event.nativeEvent;
     bodySelectionRef.current = selection;
@@ -407,6 +420,12 @@ const MarkdownEditorView = ({
         items: mediaArray,
         otherPending: context?.otherPending,
       });
+      if (context?.commitNow) {
+        // Drained during teardown: push the body to the form now rather than on the
+        // debounce, so the draft save running in the same breath sees the resolved
+        // url instead of the placeholder it replaced.
+        _debouncedOnTextChange.flush();
+      }
     }
   };
 

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../../icon';
 
 // Utils
 import applyMediaLink from '../children/formats/applyMediaLink';
+import { sweepUploadingPlaceholders } from '../children/formats/sweepUploadingPlaceholders';
 
 // Components
 import {
@@ -156,10 +157,18 @@ const MarkdownEditorView = ({
       // cached comment is appended to, not prepended (its body is short, so there is
       // no scroll problem and immediate typing is expected).
       const savedCaret = store.getState().editor.caretMap?.[_caretKey];
-      const { caret, hasSavedCaret } = resolveRestoreCaret(savedCaret, draftBody.length, isReply);
+      // Strip dead "Uploading..." placeholders left by a previous session (their
+      // uploads can no longer resolve into this editor), shifting the saved caret
+      // past the removals. The swept body flows to the form/autosave through the
+      // same debounced update this programmatic write already triggers.
+      const swept = sweepUploadingPlaceholders(
+        draftBody,
+        typeof savedCaret === 'number' ? savedCaret : undefined,
+      );
+      const { caret, hasSavedCaret } = resolveRestoreCaret(swept.caret, swept.text.length, isReply);
       _setTextAndSelection({
         selection: { start: caret, end: caret },
-        text: draftBody,
+        text: swept.text,
       });
       // Drop any caret write queued from the empty input's initial focus before this
       // load. It is stale relative to this authoritative restore (no real edit has
@@ -213,9 +222,14 @@ const MarkdownEditorView = ({
     }
   }, [isLoading]);
 
-  useEffect(() => {
-    bodyTextRef.current = draftBody;
-  }, [draftBody]);
+  // NOTE: there is deliberately no `bodyTextRef.current = draftBody` sync effect
+  // here. `draftBody` is `fields.body`, which is just this editor's own text echoed
+  // back through the 500ms debounce, so it is always as old as or older than the
+  // ref. Writing it into the ref reverted keystrokes typed since the echo was
+  // captured (text silently lost if nothing was typed afterwards) and undid the
+  // placeholder sweep the restore effect above applies. The restore effect owns the
+  // one real transition (empty ref -> loaded body); every other programmatic body
+  // change goes through _setTextAndSelection.
 
   useEffect(() => {
     if (isReply || (autoFocusText && inputRef && inputRef.current && draftBtnTooltipRegistered)) {

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -179,13 +179,20 @@ const MarkdownEditorView = ({
       // under this draft's key: on a no-caret draft that resurfaces prepend-on-type
       // next open, and on a saved-caret draft it clobbers the position being resumed.
       _persistCaret.cancel();
-      // A sweep shortened the body, so the stored caret now points past the text it
-      // belonged to. Rewrite it to the shifted position (only when one was actually
-      // saved — persisting the no-caret fallback of 0 is what the cancel above
-      // guards against). Without this, closing the draft untouched would resume at
-      // the stale offset on the next open.
-      if (hasSavedCaret && swept.text !== draftBody) {
-        dispatch(setDraftCaret(caretKeyRef.current, caret));
+      if (swept.text !== draftBody) {
+        // Commit the swept body to the form NOW rather than 500ms later on the
+        // debounce. Both saves read `fields.body`, and the unmount save reads it
+        // synchronously, so a draft closed right after opening would otherwise be
+        // written back with the dead placeholder still in it — while the caret
+        // below has already moved to swept coordinates. The two must agree.
+        handleFormUpdate('body', swept.text);
+        // A sweep shortened the body, so the stored caret now points past the text
+        // it belonged to. Rewrite it to the shifted position (only when one was
+        // actually saved — persisting the no-caret fallback of 0 is what the cancel
+        // above guards against).
+        if (hasSavedCaret) {
+          dispatch(setDraftCaret(caretKeyRef.current, caret));
+        }
       }
       // Opening a post/draft with no saved caret intentionally lands at position 0.
       // Do NOT keep an active cursor there: an auto-focused caret at 0 would prepend

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -442,24 +442,36 @@ export const UploadsGalleryModal = forwardRef(
         );
 
         // Batch insert all successful uploads in a single call to avoid race conditions
-        // where parallel onSuccess callbacks read stale body text from refs
+        // where parallel onSuccess callbacks read stale body text from refs. Every
+        // placeholder written above must get a verdict here: an upload that resolved
+        // without a url (or was skipped because the session ended mid-flight) throws
+        // nothing, so without the FAILED fallback its placeholder would stay in the
+        // body forever with no result left to resolve it. Rejections already emitted
+        // their own FAILED from _uploadImage, so they are not repeated here.
         if (shouldInsert) {
-          const successfulInserts = results
+          const resolvedInserts = results
             .map((result, index) => {
-              if (result.status === 'fulfilled' && result.value?.url) {
-                return {
-                  filename: media[index]?.filename || '',
-                  url: result.value.url,
-                  text: '',
-                  status: MediaInsertStatus.READY,
-                };
+              if (!media[index] || result.status !== 'fulfilled') {
+                return null;
               }
-              return null;
+              return result.value?.url
+                ? {
+                    filename: media[index]?.filename || '',
+                    url: result.value.url,
+                    text: '',
+                    status: MediaInsertStatus.READY,
+                  }
+                : {
+                    filename: media[index]?.filename || '',
+                    url: '',
+                    text: '',
+                    status: MediaInsertStatus.FAILED,
+                  };
             })
             .filter(Boolean);
 
-          if (successfulInserts.length > 0) {
-            _handleMediaInsertion(successfulInserts as any);
+          if (resolvedInserts.length > 0) {
+            _handleMediaInsertion(resolvedInserts as any);
           }
         }
 
@@ -525,19 +537,9 @@ export const UploadsGalleryModal = forwardRef(
 
     const _uploadImage = async (media: any, { shouldInsert } = { shouldInsert: false }) => {
       if (!isLoggedIn) {
-        // Defensive: callers gate on login before inserting placeholders, but if a
-        // placeholder was written it must not be left stuck — silently returning
-        // here would leave it with neither READY nor FAILED forever.
-        if (shouldInsert) {
-          _handleMediaInsertion([
-            {
-              filename: media.filename,
-              url: '',
-              text: '',
-              status: MediaInsertStatus.FAILED,
-            },
-          ]);
-        }
+        // Defensive: callers gate on login before any placeholder is written. If the
+        // session ended mid-flight and one exists, returning no url marks it FAILED
+        // in the batch above rather than leaving it stuck.
         return undefined;
       }
       try {

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -22,33 +22,18 @@ import { SheetNames } from '../../../navigation/sheets';
 import { selectIsLoggedIn } from '../../../redux/selectors';
 import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
+import { MediaInsertData, MediaInsertStatus, Modes } from '../types';
+
+export { MediaInsertStatus, Modes } from '../types';
+export type { MediaInsertData } from '../types';
+
 export interface UploadsGalleryModalRef {
   showModal: () => void;
-}
-
-export enum Modes {
-  MODE_IMAGE = 0,
-  MODE_VIDEO = 1,
 }
 
 const MAX_IMAGE_UPLOAD_SIZE = 30000000; // 30MB server limit
 const MAX_IMAGE_DIMENSION = 1920;
 const COMPRESS_QUALITY = 0.85;
-
-export enum MediaInsertStatus {
-  UPLOADING = 'UPLOADING',
-  READY = 'READY',
-  FAILED = 'FAILED',
-}
-
-export interface MediaInsertData {
-  url: string;
-  filename?: string;
-  text: string;
-  status: MediaInsertStatus;
-  // absent for image inserts and failed uploads; only video inserts carry it
-  mode?: Modes;
-}
 
 interface UploadsGalleryModalProps {
   postBody: string;
@@ -90,6 +75,10 @@ export const UploadsGalleryModal = forwardRef(
     const pendingInserts = useRef<MediaInsertData[]>([]);
     const isEditingRef = useRef(isEditing);
     isEditingRef.current = isEditing;
+    // Latest insert callback for code that outlives renders (upload continuations,
+    // the deferred flush timer, the unmount flush below).
+    const handleMediaInsertRef = useRef(handleMediaInsert);
+    handleMediaInsertRef.current = handleMediaInsert;
     const speakUploaderRef = useRef<any>(null);
 
     const [showModal, setShowModal] = useState(false);
@@ -185,10 +174,38 @@ export const UploadsGalleryModal = forwardRef(
 
     useEffect(() => {
       if (!isEditing && pendingInserts.current.length) {
-        handleMediaInsert(pendingInserts.current);
-        pendingInserts.current = [];
+        // isEditing goes false exactly 500ms after the last keystroke — a natural
+        // typing-pause cadence — and the insert rewrites the whole native text from
+        // the JS-side refs. Let queued native keystroke events drain briefly before
+        // committing, and re-defer if typing resumed in the meantime (the next
+        // isEditing flip re-runs this effect, so nothing is lost).
+        const timer = setTimeout(() => {
+          if (!isEditingRef.current && pendingInserts.current.length) {
+            handleMediaInsertRef.current(pendingInserts.current);
+            pendingInserts.current = [];
+          }
+        }, 100);
+        return () => clearTimeout(timer);
       }
+      return undefined;
     }, [isEditing]);
+
+    useEffect(
+      () => () => {
+        // Deferred results must not die with this component: flush them so resolved
+        // URLs still replace their placeholders in the editor refs and reach the
+        // draft autosave (both stay live in closures past unmount). Then let any
+        // upload still in flight insert directly on completion — with the component
+        // gone there is no later isEditing flip to flush a deferral, so parking it
+        // would orphan the placeholder in the saved draft.
+        if (pendingInserts.current.length) {
+          handleMediaInsertRef.current(pendingInserts.current);
+          pendingInserts.current = [];
+        }
+        isEditingRef.current = false;
+      },
+      [],
+    );
 
     useEffect(() => {
       _getMediaUploads(mode); // get media uploads when there is new update
@@ -271,6 +288,15 @@ export const UploadsGalleryModal = forwardRef(
       try {
         if (!media || media.length == 0) {
           throw new Error('New media items returned');
+        }
+
+        // Gate before any placeholder is written: a logged-out upload can never
+        // resolve, so it must never put an "Uploading..." placeholder in the body.
+        // Reachable logged-out via the share-files intent (other entry points
+        // already gate in toggleModal/pasteImageFromClipboard).
+        if (!isLoggedIn) {
+          showLoginAlert({ intl });
+          return;
         }
 
         // filter out oversized images (server limit is 30MB)
@@ -356,7 +382,10 @@ export const UploadsGalleryModal = forwardRef(
             }
           });
           if (uploadingInserts.length > 0) {
-            handleMediaInsert(uploadingInserts);
+            // Through the deferral gate like every other programmatic insert, so a
+            // body being typed into or restored is never overwritten mid-flight
+            // (matters for the share-intent path, which fires on a timer at mount).
+            _handleMediaInsertion(uploadingInserts);
           }
         }
 
@@ -460,7 +489,22 @@ export const UploadsGalleryModal = forwardRef(
     };
 
     const _uploadImage = async (media: any, { shouldInsert } = { shouldInsert: false }) => {
-      if (!isLoggedIn) return;
+      if (!isLoggedIn) {
+        // Defensive: callers gate on login before inserting placeholders, but if a
+        // placeholder was written it must not be left stuck — silently returning
+        // here would leave it with neither READY nor FAILED forever.
+        if (shouldInsert) {
+          _handleMediaInsertion([
+            {
+              filename: media.filename,
+              url: '',
+              text: '',
+              status: MediaInsertStatus.FAILED,
+            },
+          ]);
+        }
+        return undefined;
+      }
       try {
         const data = await mediaUploadMutation.mutateAsync({
           media,
@@ -559,8 +603,8 @@ export const UploadsGalleryModal = forwardRef(
     const _handleMediaInsertion = (data: MediaInsertData[]) => {
       if (isEditingRef.current) {
         pendingInserts.current.push(...data);
-      } else if (handleMediaInsert) {
-        handleMediaInsert(data);
+      } else if (handleMediaInsertRef.current) {
+        handleMediaInsertRef.current(data);
       }
     };
 
@@ -622,7 +666,7 @@ export const UploadsGalleryModal = forwardRef(
           isUploading={isAddingToUploads}
           setIsUploading={_setIsSpeakUploading}
           onVideoUploaded={(embedUrl, thumbnailUrl) => {
-            handleMediaInsert([
+            _handleMediaInsertion([
               {
                 url: embedUrl,
                 text: '',

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -23,7 +23,11 @@ import { selectIsLoggedIn } from '../../../redux/selectors';
 import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
 import { MediaInsertContext, MediaInsertData, MediaInsertStatus, Modes } from '../types';
-import { prepareInsertDispatch, shouldQueueInsert } from '../mediaInsertQueue';
+import {
+  prepareInsertDispatch,
+  registerPendingFlush,
+  shouldQueueInsert,
+} from '../mediaInsertQueue';
 import { extractUploadPlaceholderNames } from '../uploadPlaceholder';
 
 export { MediaInsertStatus, Modes } from '../types';
@@ -117,9 +121,9 @@ export const UploadsGalleryModal = forwardRef(
       );
     }, []);
 
-    const _dispatchInserts = (data: MediaInsertData[]) => {
+    const _dispatchInserts = (data: MediaInsertData[], commitNow = false) => {
       const context = prepareInsertDispatch(inFlightPlaceholders.current, data);
-      handleMediaInsertRef.current?.(data, context);
+      handleMediaInsertRef.current?.(data, { ...context, commitNow });
     };
 
     const _cancelScheduledFlush = () => {
@@ -129,14 +133,17 @@ export const UploadsGalleryModal = forwardRef(
       }
     };
 
-    const _flushPendingInserts = () => {
+    // `commitNow` is for teardown: the editor writes the body straight through
+    // instead of on its 500ms debounce, so the draft save happening in the same
+    // breath sees the resolved url rather than the placeholder.
+    const _flushPendingInserts = (commitNow = false) => {
       _cancelScheduledFlush();
       if (!pendingInserts.current.length) {
         return;
       }
       const batch = pendingInserts.current;
       pendingInserts.current = [];
-      _dispatchInserts(batch);
+      _dispatchInserts(batch, commitNow);
     };
 
     const _scheduleFlush = () => {
@@ -244,6 +251,12 @@ export const UploadsGalleryModal = forwardRef(
       return _cancelScheduledFlush;
     }, [isEditing]);
 
+    // The editor screen drains this before it saves on the way out. Its
+    // `componentWillUnmount` runs ahead of every descendant's effect cleanup, so a
+    // queue flushed only from the cleanup below lands after the draft has already
+    // been written, and the resolved url misses that save.
+    useEffect(() => registerPendingFlush(() => _flushPendingInserts(true)), []);
+
     useEffect(
       () => () => {
         // Deferred results must not die with this component: flush them so resolved
@@ -253,7 +266,7 @@ export const UploadsGalleryModal = forwardRef(
         // gone there is no later isEditing flip to flush a deferral, so parking it
         // would orphan the placeholder in the saved draft.
         isEditingRef.current = false;
-        _flushPendingInserts();
+        _flushPendingInserts(true);
       },
       [],
     );

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -24,6 +24,7 @@ import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
 import { MediaInsertContext, MediaInsertData, MediaInsertStatus, Modes } from '../types';
 import { prepareInsertDispatch, shouldQueueInsert } from '../mediaInsertQueue';
+import { extractUploadPlaceholderNames } from '../uploadPlaceholder';
 
 export { MediaInsertStatus, Modes } from '../types';
 export type { MediaInsertContext, MediaInsertData } from '../types';
@@ -101,6 +102,20 @@ export const UploadsGalleryModal = forwardRef(
     // Image gallery query (video gallery no longer needed with new embed architecture)
     const mediaUploadsQuery = imageUploadsQuery;
     const { fetchNextPage, hasNextPage, isFetchingNextPage } = mediaUploadsQuery;
+
+    // Recover the placeholders already in the body. This component unmounts whenever
+    // the user toggles preview, while its uploads keep running, so a fresh instance
+    // would otherwise start with an empty in-flight set and tell the editor there
+    // are no rival uploads — re-opening the very hole `otherPending` exists to close.
+    // A placeholder that is actually dead only costs the optional repair path, never
+    // correctness, and the draft sweep clears those on load anyway.
+    const bodyAtMountRef = useRef(postBody);
+    bodyAtMountRef.current = postBody;
+    useEffect(() => {
+      extractUploadPlaceholderNames(bodyAtMountRef.current).forEach((name) =>
+        inFlightPlaceholders.current.add(name),
+      );
+    }, []);
 
     const _dispatchInserts = (data: MediaInsertData[]) => {
       const context = prepareInsertDispatch(inFlightPlaceholders.current, data);

--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -22,10 +22,11 @@ import { SheetNames } from '../../../navigation/sheets';
 import { selectIsLoggedIn } from '../../../redux/selectors';
 import { isSignImageUnavailable } from '../../../constants/imageUpload';
 
-import { MediaInsertData, MediaInsertStatus, Modes } from '../types';
+import { MediaInsertContext, MediaInsertData, MediaInsertStatus, Modes } from '../types';
+import { prepareInsertDispatch, shouldQueueInsert } from '../mediaInsertQueue';
 
 export { MediaInsertStatus, Modes } from '../types';
-export type { MediaInsertData } from '../types';
+export type { MediaInsertContext, MediaInsertData } from '../types';
 
 export interface UploadsGalleryModalRef {
   showModal: () => void;
@@ -34,6 +35,9 @@ export interface UploadsGalleryModalRef {
 const MAX_IMAGE_UPLOAD_SIZE = 30000000; // 30MB server limit
 const MAX_IMAGE_DIMENSION = 1920;
 const COMPRESS_QUALITY = 0.85;
+// Grace period between the editor reporting "typing stopped" and a queued insert
+// rewriting the body, so keystrokes already queued natively land first.
+const INSERT_SETTLE_MS = 100;
 
 interface UploadsGalleryModalProps {
   postBody: string;
@@ -42,7 +46,7 @@ interface UploadsGalleryModalProps {
   isPreviewActive: boolean;
   allowMultiple?: boolean;
   hideToolbarExtension: () => void;
-  handleMediaInsert: (data: Array<MediaInsertData>) => void;
+  handleMediaInsert: (data: Array<MediaInsertData>, context?: MediaInsertContext) => void;
   setIsUploading: (status: boolean) => void;
   /**
    * Receives the uploaded thumbnail of a 3Speak video along with the embed it belongs to,
@@ -73,6 +77,11 @@ export const UploadsGalleryModal = forwardRef(
     const mediaUploadMutation = editorQueries.useMediaUploadMutation();
 
     const pendingInserts = useRef<MediaInsertData[]>([]);
+    const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Filenames whose "Uploading..." placeholder has been handed to the editor and
+    // not yet resolved. Sent along with each batch so the editor can tell whether an
+    // ambiguous placeholder might belong to a different upload.
+    const inFlightPlaceholders = useRef<Set<string>>(new Set());
     const isEditingRef = useRef(isEditing);
     isEditingRef.current = isEditing;
     // Latest insert callback for code that outlives renders (upload continuations,
@@ -92,6 +101,42 @@ export const UploadsGalleryModal = forwardRef(
     // Image gallery query (video gallery no longer needed with new embed architecture)
     const mediaUploadsQuery = imageUploadsQuery;
     const { fetchNextPage, hasNextPage, isFetchingNextPage } = mediaUploadsQuery;
+
+    const _dispatchInserts = (data: MediaInsertData[]) => {
+      const context = prepareInsertDispatch(inFlightPlaceholders.current, data);
+      handleMediaInsertRef.current?.(data, context);
+    };
+
+    const _cancelScheduledFlush = () => {
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+    };
+
+    const _flushPendingInserts = () => {
+      _cancelScheduledFlush();
+      if (!pendingInserts.current.length) {
+        return;
+      }
+      const batch = pendingInserts.current;
+      pendingInserts.current = [];
+      _dispatchInserts(batch);
+    };
+
+    const _scheduleFlush = () => {
+      if (flushTimerRef.current || !pendingInserts.current.length) {
+        return;
+      }
+      flushTimerRef.current = setTimeout(() => {
+        flushTimerRef.current = null;
+        if (isEditingRef.current) {
+          // typing resumed inside the settle window; the next pause re-schedules
+          return;
+        }
+        _flushPendingInserts();
+      }, INSERT_SETTLE_MS);
+    };
 
     useImperativeHandle(ref, () => ({
       toggleModal: (value: boolean, _mode: Modes = mode) => {
@@ -173,21 +218,15 @@ export const UploadsGalleryModal = forwardRef(
     }, [paramFiles]);
 
     useEffect(() => {
-      if (!isEditing && pendingInserts.current.length) {
-        // isEditing goes false exactly 500ms after the last keystroke — a natural
-        // typing-pause cadence — and the insert rewrites the whole native text from
-        // the JS-side refs. Let queued native keystroke events drain briefly before
-        // committing, and re-defer if typing resumed in the meantime (the next
-        // isEditing flip re-runs this effect, so nothing is lost).
-        const timer = setTimeout(() => {
-          if (!isEditingRef.current && pendingInserts.current.length) {
-            handleMediaInsertRef.current(pendingInserts.current);
-            pendingInserts.current = [];
-          }
-        }, 100);
-        return () => clearTimeout(timer);
+      // isEditing goes false exactly 500ms after the last keystroke — a natural
+      // typing-pause cadence — and an insert rewrites the whole native text from the
+      // JS-side refs. The scheduled flush lets queued native keystroke events drain
+      // first, and re-defers if typing resumed (the next isEditing flip re-runs this
+      // effect, so nothing is lost).
+      if (!isEditing) {
+        _scheduleFlush();
       }
-      return undefined;
+      return _cancelScheduledFlush;
     }, [isEditing]);
 
     useEffect(
@@ -198,11 +237,8 @@ export const UploadsGalleryModal = forwardRef(
         // upload still in flight insert directly on completion — with the component
         // gone there is no later isEditing flip to flush a deferral, so parking it
         // would orphan the placeholder in the saved draft.
-        if (pendingInserts.current.length) {
-          handleMediaInsertRef.current(pendingInserts.current);
-          pendingInserts.current = [];
-        }
         isEditingRef.current = false;
+        _flushPendingInserts();
       },
       [],
     );
@@ -337,7 +373,6 @@ export const UploadsGalleryModal = forwardRef(
             element.mime !== 'image/gif' &&
             (element.width > MAX_IMAGE_DIMENSION || element.height > MAX_IMAGE_DIMENSION)
           ) {
-            // eslint-disable-next-line no-await-in-loop
             const resizeOpt =
               element.width >= element.height
                 ? { width: MAX_IMAGE_DIMENSION }
@@ -601,11 +636,14 @@ export const UploadsGalleryModal = forwardRef(
     };
 
     const _handleMediaInsertion = (data: MediaInsertData[]) => {
-      if (isEditingRef.current) {
+      if (shouldQueueInsert(isEditingRef.current, pendingInserts.current.length)) {
         pendingInserts.current.push(...data);
-      } else if (handleMediaInsertRef.current) {
-        handleMediaInsertRef.current(data);
+        if (!isEditingRef.current) {
+          _scheduleFlush();
+        }
+        return;
       }
+      _dispatchInserts(data);
     };
 
     // fetch images from server
@@ -633,7 +671,9 @@ export const UploadsGalleryModal = forwardRef(
         });
       });
 
-      handleMediaInsert(data);
+      // Through the same gate as every other insert: these carry no placeholder and
+      // land at the caret, so they must not overtake a queued placeholder either.
+      _handleMediaInsertion(data);
     };
 
     const data = mediaUploadsQuery.data.slice();

--- a/src/components/uploadsGalleryModal/mediaInsertQueue.test.ts
+++ b/src/components/uploadsGalleryModal/mediaInsertQueue.test.ts
@@ -1,4 +1,9 @@
-import { prepareInsertDispatch, shouldQueueInsert } from './mediaInsertQueue';
+import {
+  flushPendingEditorWork,
+  prepareInsertDispatch,
+  registerPendingFlush,
+  shouldQueueInsert,
+} from './mediaInsertQueue';
 import { MediaInsertData, MediaInsertStatus } from './types';
 
 const uploading = (filename: string): MediaInsertData => ({
@@ -83,5 +88,46 @@ describe('prepareInsertDispatch', () => {
     ]);
     expect(context.otherPending).toEqual(['a.jpg']);
     expect([...inFlight]).toEqual(['a.jpg']);
+  });
+});
+
+describe('registerPendingFlush / flushPendingEditorWork', () => {
+  it('runs registered flushes and stops after unregister', () => {
+    const calls: string[] = [];
+    const un = registerPendingFlush(() => calls.push('a'));
+    flushPendingEditorWork();
+    expect(calls).toEqual(['a']);
+
+    un();
+    flushPendingEditorWork();
+    expect(calls).toEqual(['a']);
+  });
+
+  it('runs every registered flush, not just the first', () => {
+    const calls: string[] = [];
+    const unA = registerPendingFlush(() => calls.push('a'));
+    const unB = registerPendingFlush(() => calls.push('b'));
+    flushPendingEditorWork();
+    expect(calls.sort()).toEqual(['a', 'b']);
+    unA();
+    unB();
+  });
+
+  it('keeps going when one flush throws, so teardown is never broken', () => {
+    const calls: string[] = [];
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const unA = registerPendingFlush(() => {
+      throw new Error('boom');
+    });
+    const unB = registerPendingFlush(() => calls.push('b'));
+    expect(() => flushPendingEditorWork()).not.toThrow();
+    expect(calls).toEqual(['b']);
+    warn.mockRestore();
+    unA();
+    unB();
+  });
+
+  it('is a no-op with nothing registered', () => {
+    expect(() => flushPendingEditorWork()).not.toThrow();
   });
 });

--- a/src/components/uploadsGalleryModal/mediaInsertQueue.test.ts
+++ b/src/components/uploadsGalleryModal/mediaInsertQueue.test.ts
@@ -1,0 +1,87 @@
+import { prepareInsertDispatch, shouldQueueInsert } from './mediaInsertQueue';
+import { MediaInsertData, MediaInsertStatus } from './types';
+
+const uploading = (filename: string): MediaInsertData => ({
+  filename,
+  url: '',
+  text: '',
+  status: MediaInsertStatus.UPLOADING,
+});
+
+const ready = (filename: string, url = 'https://x/y.png'): MediaInsertData => ({
+  filename,
+  url,
+  text: '',
+  status: MediaInsertStatus.READY,
+});
+
+const failed = (filename: string): MediaInsertData => ({
+  filename,
+  url: '',
+  text: '',
+  status: MediaInsertStatus.FAILED,
+});
+
+describe('shouldQueueInsert', () => {
+  it('queues while the user is typing', () => {
+    expect(shouldQueueInsert(true, 0)).toBe(true);
+  });
+
+  it('dispatches directly when idle with nothing queued', () => {
+    expect(shouldQueueInsert(false, 0)).toBe(false);
+  });
+
+  it('queues behind an existing item even when typing has stopped', () => {
+    // the ordering guard: a READY result must never overtake its own queued
+    // UPLOADING placeholder, or the image is dropped and the placeholder sticks
+    expect(shouldQueueInsert(false, 1)).toBe(true);
+  });
+});
+
+describe('prepareInsertDispatch', () => {
+  it('reports no rivals for a lone upload', () => {
+    const inFlight = new Set<string>();
+    expect(prepareInsertDispatch(inFlight, [uploading('a.jpg')])).toEqual({ otherPending: [] });
+    expect([...inFlight]).toEqual(['a.jpg']);
+  });
+
+  it('excludes the batch’s own filenames from otherPending', () => {
+    const inFlight = new Set(['a.jpg']);
+    const context = prepareInsertDispatch(inFlight, [ready('a.jpg')]);
+    expect(context.otherPending).toEqual([]);
+  });
+
+  it('reports another upload still in flight as a rival', () => {
+    const inFlight = new Set(['b.jpg']);
+    const context = prepareInsertDispatch(inFlight, [ready('a.jpg')]);
+    expect(context.otherPending).toEqual(['b.jpg']);
+  });
+
+  it('clears an upload from the in-flight set once it resolves', () => {
+    const inFlight = new Set<string>();
+    prepareInsertDispatch(inFlight, [uploading('a.jpg'), uploading('b.jpg')]);
+    expect([...inFlight].sort()).toEqual(['a.jpg', 'b.jpg']);
+
+    prepareInsertDispatch(inFlight, [ready('a.jpg')]);
+    expect([...inFlight]).toEqual(['b.jpg']);
+
+    prepareInsertDispatch(inFlight, [failed('b.jpg')]);
+    expect([...inFlight]).toEqual([]);
+  });
+
+  it('nets out an UPLOADING and its READY flushed in the same batch', () => {
+    const inFlight = new Set<string>();
+    const context = prepareInsertDispatch(inFlight, [uploading('a.jpg'), ready('a.jpg')]);
+    expect(context.otherPending).toEqual([]);
+    expect([...inFlight]).toEqual([]);
+  });
+
+  it('ignores items with no filename (gallery taps and video embeds)', () => {
+    const inFlight = new Set(['a.jpg']);
+    const context = prepareInsertDispatch(inFlight, [
+      { url: 'https://x/y.png', text: '', status: MediaInsertStatus.READY },
+    ]);
+    expect(context.otherPending).toEqual(['a.jpg']);
+    expect([...inFlight]).toEqual(['a.jpg']);
+  });
+});

--- a/src/components/uploadsGalleryModal/mediaInsertQueue.ts
+++ b/src/components/uploadsGalleryModal/mediaInsertQueue.ts
@@ -17,6 +17,42 @@ import { MediaInsertContext, MediaInsertData, MediaInsertStatus } from './types'
 export const shouldQueueInsert = (isEditing: boolean, pendingCount: number) =>
   isEditing || pendingCount > 0;
 
+const pendingFlushes = new Set<() => void>();
+
+/**
+ * Register a "commit whatever is pending, now" callback, and get back its
+ * unregister.
+ *
+ * The editor screen has to be able to drain this work BEFORE it saves. Its own
+ * `componentWillUnmount` runs in the commit phase, ahead of every descendant's
+ * effect cleanup, so a queue flushed from the gallery's own unmount runs after the
+ * screen has already written the draft — the resolved url would reach the body too
+ * late for that save. A registry rather than props because the queue sits three
+ * components below the screen (screen -> editor view -> toolbar -> gallery).
+ */
+export const registerPendingFlush = (flush: () => void) => {
+  pendingFlushes.add(flush);
+  return () => {
+    pendingFlushes.delete(flush);
+  };
+};
+
+/**
+ * Run every registered flush. Safe to call with none registered, and safe when
+ * another editing surface (the quick-post modal) has one registered too: each
+ * callback only commits its own pending work into its own editor.
+ */
+export const flushPendingEditorWork = () => {
+  pendingFlushes.forEach((flush) => {
+    try {
+      flush();
+    } catch (err) {
+      // a teardown-time commit must never break the unmount it runs inside
+      console.warn('pending editor flush failed', err);
+    }
+  });
+};
+
 /**
  * Advance the set of uploads whose placeholder is in the body but unresolved, and
  * return the context for the batch about to be dispatched.

--- a/src/components/uploadsGalleryModal/mediaInsertQueue.ts
+++ b/src/components/uploadsGalleryModal/mediaInsertQueue.ts
@@ -1,0 +1,49 @@
+import { MediaInsertContext, MediaInsertData, MediaInsertStatus } from './types';
+
+/**
+ * Ordering policy for media inserts handed to the editor.
+ *
+ * Inserts rewrite the whole body from JS-side refs, so they are deferred while the
+ * user is typing. The subtle part is that a deferral makes ORDER load-bearing: an
+ * upload's READY result must never reach the editor before its own "Uploading..."
+ * placeholder, or the result finds nothing to replace (the image is dropped) and the
+ * placeholder is written afterwards with nothing left to resolve it — the stuck
+ * placeholder users report. Hence anything queued forces everything behind it to
+ * queue too, however briefly the queue is non-empty.
+ *
+ * Kept dependency-free so it can be unit-tested without the gallery's native module
+ * graph; the container owns only the timers and the actual dispatch.
+ */
+export const shouldQueueInsert = (isEditing: boolean, pendingCount: number) =>
+  isEditing || pendingCount > 0;
+
+/**
+ * Advance the set of uploads whose placeholder is in the body but unresolved, and
+ * return the context for the batch about to be dispatched.
+ *
+ * `otherPending` is computed BEFORE the update and excludes this batch's own
+ * filenames, so it names exactly the uploads whose placeholders this batch must not
+ * touch. The editor refuses to repair an ambiguous placeholder while it is non-empty,
+ * which is what stops one upload's url landing in another image's slot.
+ */
+export const prepareInsertDispatch = (
+  inFlight: Set<string>,
+  data: MediaInsertData[],
+): MediaInsertContext => {
+  const batchNames = new Set(data.map((item) => item.filename).filter(Boolean) as string[]);
+  const otherPending = [...inFlight].filter((name) => !batchNames.has(name));
+
+  data.forEach((item) => {
+    if (!item.filename) {
+      return;
+    }
+    if (item.status === MediaInsertStatus.UPLOADING) {
+      inFlight.add(item.filename);
+    } else {
+      // READY or FAILED: this upload's placeholder is resolved either way
+      inFlight.delete(item.filename);
+    }
+  });
+
+  return { otherPending };
+};

--- a/src/components/uploadsGalleryModal/types.ts
+++ b/src/components/uploadsGalleryModal/types.ts
@@ -28,4 +28,10 @@ export interface MediaInsertContext {
    * upload's url into another image's slot.
    */
   otherPending?: string[];
+  /**
+   * Commit the resulting body immediately instead of on the editor's 500ms
+   * debounce. Set when the batch is being drained during teardown, where a draft
+   * save is about to read the body and must see the resolved url.
+   */
+  commitNow?: boolean;
 }

--- a/src/components/uploadsGalleryModal/types.ts
+++ b/src/components/uploadsGalleryModal/types.ts
@@ -19,3 +19,13 @@ export interface MediaInsertData {
   // absent for image inserts and failed uploads; only video inserts carry it
   mode?: Modes;
 }
+
+export interface MediaInsertContext {
+  /**
+   * Filenames of OTHER uploads whose "Uploading..." placeholder may still be in
+   * the body when this batch is applied. The editor uses it to refuse repairing an
+   * ambiguous placeholder that could belong to one of them, which would write this
+   * upload's url into another image's slot.
+   */
+  otherPending?: string[];
+}

--- a/src/components/uploadsGalleryModal/types.ts
+++ b/src/components/uploadsGalleryModal/types.ts
@@ -1,0 +1,21 @@
+// Kept dependency-free so pure editor helpers (applyMediaLink and its tests) can
+// import these without pulling in the gallery container's native module graph.
+export enum Modes {
+  MODE_IMAGE = 0,
+  MODE_VIDEO = 1,
+}
+
+export enum MediaInsertStatus {
+  UPLOADING = 'UPLOADING',
+  READY = 'READY',
+  FAILED = 'FAILED',
+}
+
+export interface MediaInsertData {
+  url: string;
+  filename?: string;
+  text: string;
+  status: MediaInsertStatus;
+  // absent for image inserts and failed uploads; only video inserts carry it
+  mode?: Modes;
+}

--- a/src/components/uploadsGalleryModal/uploadPlaceholder.test.ts
+++ b/src/components/uploadsGalleryModal/uploadPlaceholder.test.ts
@@ -1,0 +1,27 @@
+import { extractUploadPlaceholderNames } from './uploadPlaceholder';
+
+describe('extractUploadPlaceholderNames', () => {
+  it('returns nothing for a body with no placeholder', () => {
+    expect(extractUploadPlaceholderNames('hello ![alt](https://x/y.png)')).toEqual([]);
+  });
+
+  it('returns nothing for an empty or missing body', () => {
+    expect(extractUploadPlaceholderNames('')).toEqual([]);
+    expect(extractUploadPlaceholderNames(undefined)).toEqual([]);
+  });
+
+  it('extracts a single filename', () => {
+    expect(extractUploadPlaceholderNames('a\n![](Uploading... img.jpg)\nb')).toEqual(['img.jpg']);
+  });
+
+  it('extracts filenames containing parentheses', () => {
+    expect(extractUploadPlaceholderNames('![](Uploading... IMG_2024 (1).jpg)')).toEqual([
+      'IMG_2024 (1).jpg',
+    ]);
+  });
+
+  it('extracts every placeholder, ignoring alt text and real images', () => {
+    const body = '![ok](https://x/y.png)\n![](Uploading... a.jpg)\n![zz](Uploading... b.png)\nend';
+    expect(extractUploadPlaceholderNames(body)).toEqual(['a.jpg', 'b.png']);
+  });
+});

--- a/src/components/uploadsGalleryModal/uploadPlaceholder.test.ts
+++ b/src/components/uploadsGalleryModal/uploadPlaceholder.test.ts
@@ -25,3 +25,11 @@ describe('extractUploadPlaceholderNames', () => {
     expect(extractUploadPlaceholderNames(body)).toEqual(['a.jpg', 'b.png']);
   });
 });
+
+describe('uploadPlaceholderPattern', () => {
+  it('does not match markdown that lacks the prefix’s trailing space', () => {
+    // the editor always writes 'Uploading... <name>'; anything else is the user's
+    // own markdown and must survive the sweep untouched
+    expect(extractUploadPlaceholderNames('![](Uploading...img.jpg)')).toEqual([]);
+  });
+});

--- a/src/components/uploadsGalleryModal/uploadPlaceholder.ts
+++ b/src/components/uploadsGalleryModal/uploadPlaceholder.ts
@@ -8,13 +8,17 @@
  */
 export const uploadPlaceholderPrefix = 'Uploading... ';
 
+// Matches the literal prefix INCLUDING its trailing space, so only text this editor
+// actually wrote can be repaired or swept; `![](Uploading...x.jpg)` is someone's own
+// markdown and must be left alone (the sweep deletes what it matches).
+//
 // The filename part allows one level of balanced parentheses, because gallery
 // filenames routinely contain them (`IMG_2024 (1).jpg`); stopping at the first `)`
 // matched only a prefix and left `.jpg)` behind as garbage. Alt text and filename
 // both exclude newlines so a match can never swallow surrounding body text, and the
 // alternation cannot run past the placeholder's own closing paren.
 export const uploadPlaceholderPattern = () =>
-  /!\[[^\]\n]*\]\(Uploading\.\.\.(?:[^()\n]|\([^()\n]*\))*\)/g;
+  /!\[[^\]\n]*\]\(Uploading\.\.\. (?:[^()\n]|\([^()\n]*\))*\)/g;
 
 /**
  * Filenames of the upload placeholders currently in `text`.

--- a/src/components/uploadsGalleryModal/uploadPlaceholder.ts
+++ b/src/components/uploadsGalleryModal/uploadPlaceholder.ts
@@ -1,0 +1,43 @@
+/**
+ * The `![alt](Uploading... filename)` placeholder the editor writes while an upload
+ * is in flight, and the tools for finding one again afterwards.
+ *
+ * Lives here rather than in the editor so both sides of the upload flow can use it
+ * without importing each other, and stays dependency-free so it can be unit-tested
+ * without either module graph.
+ */
+export const uploadPlaceholderPrefix = 'Uploading... ';
+
+// The filename part allows one level of balanced parentheses, because gallery
+// filenames routinely contain them (`IMG_2024 (1).jpg`); stopping at the first `)`
+// matched only a prefix and left `.jpg)` behind as garbage. Alt text and filename
+// both exclude newlines so a match can never swallow surrounding body text, and the
+// alternation cannot run past the placeholder's own closing paren.
+export const uploadPlaceholderPattern = () =>
+  /!\[[^\]\n]*\]\(Uploading\.\.\.(?:[^()\n]|\([^()\n]*\))*\)/g;
+
+/**
+ * Filenames of the upload placeholders currently in `text`.
+ *
+ * Lets a freshly mounted gallery recover which uploads still own a placeholder in
+ * the body — the preview toggle unmounts it while uploads keep running, and its
+ * in-flight set would otherwise start empty and under-report those rivals.
+ */
+export const extractUploadPlaceholderNames = (text?: string): string[] => {
+  if (!text || !text.includes(`(${uploadPlaceholderPrefix.trimEnd()}`)) {
+    return [];
+  }
+
+  const names: string[] = [];
+  const pattern = uploadPlaceholderPattern();
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const open = match[0].indexOf('](') + 2;
+    const name = match[0].slice(open, -1).slice(uploadPlaceholderPrefix.length);
+    if (name) {
+      names.push(name);
+    }
+    match = pattern.exec(text);
+  }
+  return names;
+};

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -751,6 +751,18 @@ class EditorContainer extends Component<any, any> {
           return;
         }
 
+        // The guard at the top of this method ran before the awaits above, so a save
+        // that started just before the user hit publish would land here afterwards
+        // and rewrite (or recreate) the server draft the publish flow is asking the
+        // user about. Re-check right before the mutation; the local cache is already
+        // written and is guarded on its own.
+        if (this._isPublished) {
+          if (this._isMounted) {
+            this.setState({ isDraftSaving: false });
+          }
+          return;
+        }
+
         // update draft is draftId is present
         if (draftId && draftField && !saveAsNew) {
           await updateDraft(

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -957,6 +957,14 @@ class EditorContainer extends Component<any, any> {
       return;
     }
 
+    // Once published, never write the draft cache again (same rule _saveDraftToDB
+    // applies). Debounced/late saves — the 300ms form timer, an image upload
+    // resolving after the editor closed — would otherwise re-create the cache
+    // entry that publishing just deleted, resurfacing the post as a ghost draft.
+    if (this._isPublished) {
+      return;
+    }
+
     const { currentAccount, dispatch } = this.props;
     const username = currentAccount && currentAccount.name ? currentAccount.name : '';
 

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -1463,6 +1463,11 @@ class EditorContainer extends Component<any, any> {
         });
 
         AsyncStorage.setItem('temp-reply', '');
+        // Mark published BEFORE clearing the cache below, so a late autosave — the
+        // unmount save, or an image upload resolving after the editor closed —
+        // cannot re-create the entry we are about to delete and leave the comment
+        // box pre-filled with an already-published reply.
+        this._isPublished = true;
         this._handleSubmitSuccess();
 
         // delete quick comment draft cache if it exist (from replyCache)

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -36,13 +36,16 @@ import PostOptionsModal from '../children/postOptionsModal';
 import SaveTemplateModal from '../children/saveTemplateModal';
 import { AiToolsMeta, CommunityRole, CommunityTypeId } from '../../../providers/hive/hive.types';
 import { flushPendingEditorWork } from '../../../components/uploadsGalleryModal/mediaInsertQueue';
+import { resolveDraftSaveBody } from '../../../utils/editorDraftBody';
 
 class EditorScreen extends Component<any, any> {
   changeTimer: any;
 
-  // Latest body handed to `_handleFormUpdate`, recorded before its awaits so the
-  // unmount save is not limited to what has already reached state.
+  // Latest body handed to `_handleFormUpdate`, and whether it is still in flight
+  // (recorded but not yet committed to state). See `resolveDraftSaveBody`.
   _latestBody: string | undefined;
+
+  _latestBodyPending = false;
 
   /* Props
    * ------------------------------------------------
@@ -355,7 +358,11 @@ class EditorScreen extends Component<any, any> {
 
     if (componentID === 'body') {
       fields.body = content;
+      // Recorded before the awaits below so the unmount save is not limited to what
+      // has already reached state; marked pending until it lands there, so a body
+      // replaced afterwards by a clear or a late draft load is not overridden by it.
       this._latestBody = content;
+      this._latestBodyPending = true;
     } else if (componentID === 'title') {
       fields.title = content;
     } else if (componentID === 'tag-area') {
@@ -398,6 +405,11 @@ class EditorScreen extends Component<any, any> {
     this.setState(
       (prev: any) => ({ fields: { ...fields, aiTools: prev.fields.aiTools } }),
       () => {
+        // Only the update that recorded the current value clears the flag, so a
+        // newer body still in flight keeps its precedence.
+        if (componentID === 'body' && this._latestBody === content) {
+          this._latestBodyPending = false;
+        }
         this._handleIsFormValid();
       },
     );
@@ -475,13 +487,8 @@ class EditorScreen extends Component<any, any> {
     const { saveDraftToDB } = this.props;
     const { fields } = this.state;
 
-    // `_handleFormUpdate` records the body synchronously but only reaches state
-    // after an await, so on the unmount path state is a step behind. Prefer the
-    // recorded value so a body just committed by the drain above is the one saved.
-    const _fields =
-      typeof this._latestBody === 'string' && this._latestBody !== fields.body
-        ? { ...fields, body: this._latestBody }
-        : fields;
+    const _body = resolveDraftSaveBody(fields.body, this._latestBody, this._latestBodyPending);
+    const _fields = _body === fields.body ? fields : { ...fields, body: _body };
 
     // save draft only if any of field is valid
     if (_fields.body || _fields.title) {

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -35,9 +35,14 @@ import styles from './editorScreenStyles';
 import PostOptionsModal from '../children/postOptionsModal';
 import SaveTemplateModal from '../children/saveTemplateModal';
 import { AiToolsMeta, CommunityRole, CommunityTypeId } from '../../../providers/hive/hive.types';
+import { flushPendingEditorWork } from '../../../components/uploadsGalleryModal/mediaInsertQueue';
 
 class EditorScreen extends Component<any, any> {
   changeTimer: any;
+
+  // Latest body handed to `_handleFormUpdate`, recorded before its awaits so the
+  // unmount save is not limited to what has already reached state.
+  _latestBody: string | undefined;
 
   /* Props
    * ------------------------------------------------
@@ -107,6 +112,13 @@ class EditorScreen extends Component<any, any> {
 
   componentWillUnmount() {
     const { isEdit } = this.props;
+    // Commit anything the editor is still holding — keystrokes inside the 500ms
+    // debounce, and an upload result queued behind live typing — BEFORE saving.
+    // This runs ahead of every descendant's effect cleanup, so without draining
+    // here the save below would write the body as it was before those landed,
+    // storing an unresolved "Uploading..." placeholder for an image that had in
+    // fact arrived.
+    flushPendingEditorWork();
     if (!isEdit) {
       this._saveDraftToDB();
     }
@@ -343,6 +355,7 @@ class EditorScreen extends Component<any, any> {
 
     if (componentID === 'body') {
       fields.body = content;
+      this._latestBody = content;
     } else if (componentID === 'title') {
       fields.title = content;
     } else if (componentID === 'tag-area') {
@@ -462,9 +475,17 @@ class EditorScreen extends Component<any, any> {
     const { saveDraftToDB } = this.props;
     const { fields } = this.state;
 
+    // `_handleFormUpdate` records the body synchronously but only reaches state
+    // after an await, so on the unmount path state is a step behind. Prefer the
+    // recorded value so a body just committed by the drain above is the one saved.
+    const _fields =
+      typeof this._latestBody === 'string' && this._latestBody !== fields.body
+        ? { ...fields, body: this._latestBody }
+        : fields;
+
     // save draft only if any of field is valid
-    if (fields.body || fields.title) {
-      saveDraftToDB(fields, saveAsNew);
+    if (_fields.body || _fields.title) {
+      saveDraftToDB(_fields, saveAsNew);
     }
   }
 

--- a/src/utils/editorDraftBody.test.ts
+++ b/src/utils/editorDraftBody.test.ts
@@ -1,0 +1,38 @@
+import { resolveDraftSaveBody } from './editorDraftBody';
+
+describe('resolveDraftSaveBody', () => {
+  it('uses the recorded body while its update is still in flight', () => {
+    // the unmount path: the drain committed a resolved image url, but setState
+    // has not landed, so state still holds the "Uploading..." placeholder
+    expect(
+      resolveDraftSaveBody('before ![](Uploading... a.jpg)', 'before ![](https://x/a.png)', true),
+    ).toBe('before ![](https://x/a.png)');
+  });
+
+  it('uses state once the recorded update has landed', () => {
+    expect(resolveDraftSaveBody('committed', 'committed', false)).toBe('committed');
+  });
+
+  it('does not resurrect a cleared body from a settled recorded value', () => {
+    // Clear empties fields.body without going through _handleFormUpdate; the
+    // previously recorded body has already landed, so it must not win here
+    expect(resolveDraftSaveBody('', 'text the user cleared', false)).toBe('');
+  });
+
+  it('does not override a draft that arrived after the recorded update landed', () => {
+    expect(resolveDraftSaveBody('body from the loaded draft', 'earlier typing', false)).toBe(
+      'body from the loaded draft',
+    );
+  });
+
+  it('falls back to state when nothing was ever recorded', () => {
+    expect(resolveDraftSaveBody('only state', undefined, false)).toBe('only state');
+    expect(resolveDraftSaveBody('only state', undefined, true)).toBe('only state');
+  });
+
+  it('honours a recorded empty body that has not landed yet', () => {
+    // clearing the editor is a real body update: an empty string is a value here,
+    // not a missing one
+    expect(resolveDraftSaveBody('stale text', '', true)).toBe('');
+  });
+});

--- a/src/utils/editorDraftBody.ts
+++ b/src/utils/editorDraftBody.ts
@@ -1,0 +1,29 @@
+/**
+ * Which body a draft save should write.
+ *
+ * `_handleFormUpdate` records the body it was handed before it awaits metadata
+ * extraction, so on the unmount path the component's state is still a step behind
+ * it. The save has to prefer that recorded value, or a body committed moments
+ * earlier — the last keystrokes of a debounce window, or an upload result drained
+ * on the way out — is dropped from the saved draft.
+ *
+ * It must prefer it ONLY while that update is still in flight, though. Once it has
+ * landed in state the recorded value is just a copy, and something else may have
+ * replaced the body since without going through `_handleFormUpdate` at all: a
+ * clear resets it to empty, and a draft arriving asynchronously overwrites it via
+ * derived state. Preferring a stale copy in either case would put the cleared or
+ * replaced text back into the saved draft.
+ *
+ * Kept dependency-free so it can be unit-tested without the editor screen's module
+ * graph.
+ */
+export const resolveDraftSaveBody = (
+  stateBody: string | undefined,
+  recordedBody: string | undefined,
+  isRecordedPending: boolean,
+): string | undefined => {
+  if (isRecordedPending && typeof recordedBody === 'string') {
+    return recordedBody;
+  }
+  return stateBody;
+};


### PR DESCRIPTION
Closes #3525

From a user report (OPPO A3x, Android): uploading a photo in the post editor stays stuck on "Uploading...", typed text gets reversed or deleted, and the image sometimes appears between the wrong text. All three are the same area: the upload placeholder flow rewrites the whole body from JS-side refs, which collides with typing on a slow device.

## Text getting reversed or deleted

`markdownEditorView` had an effect writing `draftBody` back into `bodyTextRef`. `draftBody` is `fields.body`, which is only this editor's own text echoed back through a 500ms debounce, so it is never newer than the ref. It became destructive because `editorScreen.componentDidUpdate` calls `_handleFormUpdate()` with no arguments whenever `isUploading` flips, feeding the stale state body back through that echo. That happens exactly at upload start and upload finish, reverting every keystroke typed since the last debounce. The effect is removed; the restore effect owns the one real empty-to-loaded transition.

## Image landing between the wrong text

When the exact placeholder was not found, the READY handler fell through to inserting the url at the live caret, mid-sentence, while the mangled placeholder stayed behind. It now repairs the single unambiguous placeholder in place, and otherwise drops the body insert rather than writing at the caret (the upload is still in the gallery). Deliberate inserts with no placeholder (gallery tap, video embed) are unaffected.

## Placeholders that could never resolve

- Deferred results were dropped when the editor closed, so the saved draft kept a dead placeholder forever. They now flush on the way out, and uploads finishing after that insert directly.
- An upload resolving without a url produced neither READY nor FAILED. Every placeholder now gets a verdict.
- Logged-out uploads wrote a placeholder that could never resolve. Uploads are gated on login before any placeholder is written (the share-intent path had no gate at all).
- Bodies that already carry a dead placeholder are swept when loaded into the editor, with the saved caret shifted past the removals.

## Ordering

Deferring inserts makes order load-bearing, in two places.

Within the queue: a result must never reach the editor before its own placeholder, so a batch queues behind anything already queued, not only while typing. A queued flush waits 100ms after typing stops so queued keystrokes land first, re-deferring if typing resumed.

Against the draft save: `EditorScreen.componentWillUnmount` runs ahead of every descendant's effect cleanup, so a queue drained from the gallery's own cleanup landed after the draft had already been written. Navigating away while typing with an upload queued saved the unresolved placeholder, and the url reached only the local cache. The screen now drains pending editor work before saving, a teardown flush pushes the body straight through instead of on the debounce, and the save prefers the body recorded synchronously by `_handleFormUpdate` over the state copy that is a step behind. That last part also stops keystrokes inside the debounce window being dropped from the unmount save.

## Ambiguity

Repairing an ambiguous placeholder can write one upload's url into another image's slot, so it is refused whenever another upload could own the candidate. The gallery reports the unresolved filenames with each batch and recovers them from the body on mount, since the preview toggle unmounts it while uploads keep running. The guard is deliberately blunt: over-reporting a rival drops an optional repair, under-reporting corrupts the post.

## Also fixed here

- Placeholder matching handles filenames containing parentheses (`IMG_2024 (1).jpg`), which previously matched a prefix and left `.jpg)` behind as garbage, and requires the prefix's trailing space so user-authored markdown is never swept.
- A failed upload no longer leaves a blank line where the image was, and a caret inside the removed placeholder lands at its start.
- The selection handed to the native input is clamped to the body, since a range selection straddling an edited placeholder could end past the text and Android throws on that rather than clamping.
- Caret shifts at the exact end of a replaced placeholder, and CRLF bodies do not keep a stray carriage return.
- `_saveCurrentDraft` is guarded by `_isPublished` (now also set on reply publish), and `_saveDraftToDB` re-checks it immediately before the remote mutation, so a late autosave cannot re-create the draft or reply cache entry the publish just deleted.

## Testing

986 unit tests pass, typecheck and lint clean. The queue policy, placeholder matching, the sweep and the flush registry are covered by new unit tests in dependency-free modules. Every new guard was mutation-tested (deleted, suite re-run, confirmed red); one fixture was rewritten after a guard survived deletion.

## Known limitation, not addressed here

Toggling preview unmounts the editor toolbar and with it the gallery, while uploads continue. Placeholder repair now survives that, but an upload completing during preview still bypasses the typing gate, and the share-intent effect re-runs on the way back. A remote draft save can also still complete after publication, since the re-check cannot cover the request itself. Both predate this change and are tracked in #3527.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved media upload handling, including parallel uploads and reliable placeholder replacement.
  - Drafts now save the latest editor changes and completed media uploads when leaving the editor.
- **Bug Fixes**
  - Removed abandoned upload placeholders when restoring drafts.
  - Prevented ambiguous or failed uploads from altering unrelated content.
  - Preserved and corrected cursor and text selections after media changes.
  - Prevented drafts from reappearing after a reply is published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->