### PR TITLE
fix: safe-area insets and touch targets around the newsletter digests screen

### DIFF
--- a/src/components/basicHeader/view/basicHeaderStyles.ts
+++ b/src/components/basicHeader/view/basicHeaderStyles.ts
@@ -10,7 +10,9 @@ export default EStyleSheet.create({
     backgroundColor: '$primaryBackgroundColor',
     alignItems: 'center',
   },
-  safeArea: {
+  // Background only, no inset. The top safe-area inset is the screen's job: every
+  // screen rendering BasicHeader wraps it in its own SafeAreaView.
+  headerBackground: {
     backgroundColor: '$primaryBackgroundColor',
     paddingHorizontal: 0,
   },

--- a/src/components/basicHeader/view/basicHeaderView.tsx
+++ b/src/components/basicHeader/view/basicHeaderView.tsx
@@ -111,7 +111,7 @@ const BasicHeaderView = ({
    */
 
   return (
-    <View style={styles.safeArea}>
+    <View style={styles.headerBackground}>
       <View style={styles.container}>
         <View style={styles.backWrapper}>
           <IconButton

--- a/src/components/newsletterPostPrompt/newsletterPostPrompt.tsx
+++ b/src/components/newsletterPostPrompt/newsletterPostPrompt.tsx
@@ -10,6 +10,12 @@ import { getItemFromStorage, setItemToStorage } from '../../storage/storage';
 import { IconButton } from '../iconButton';
 import { pickPostDigestTarget, postPromptStorageKey } from './postDigestTarget';
 
+// The dismiss is a fixed 30x30 and its write is permanent, so grow the target
+// vertically and toward the card edge. NOT to the left: the Subscribe pill is
+// flush against it and this button paints later, so left slop would let it
+// swallow Subscribe taps and dismiss the card for good.
+const DISMISS_HIT_SLOP = { top: 8, bottom: 8, left: 0, right: 8 };
+
 interface Props {
   post:
     | { author?: string; category?: string; parent_author?: string; depth?: number }
@@ -109,6 +115,7 @@ const NewsletterPostPrompt = ({ post }: Props) => {
         size={18}
         color={EStyleSheet.value('$primaryDarkGray')}
         onPress={_handleDismiss}
+        hitSlop={DISMISS_HIT_SLOP}
       />
     </View>
   );

--- a/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
+++ b/src/components/newsletterSenderInfo/newsletterSenderInfo.tsx
@@ -11,6 +11,10 @@ import { useAppDispatch, useAuth } from '../../hooks';
 import { toastNotification } from '../../redux/actions/uiAction';
 import { IconButton } from '../iconButton';
 
+// The copy button is a fixed 30x30. Kept to 4 on the right so the target stays
+// inside the 8pt gap before "Manage" and cannot swallow taps meant for it.
+const COPY_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 4 };
+
 interface Props {
   username: string;
 }
@@ -56,6 +60,7 @@ const NewsletterSenderInfo = ({ username }: Props) => {
         size={18}
         color={EStyleSheet.value('$primaryDarkGray')}
         onPress={_handleCopyLink}
+        hitSlop={COPY_HIT_SLOP}
       />
       <TouchableOpacity onPress={() => navigation.navigate(ROUTES.SCREENS.EMAIL_DIGESTS)}>
         <Text style={styles.manageText} numberOfLines={1}>

--- a/src/screens/aiImageGenerator/screen/aiImageGeneratorScreen.tsx
+++ b/src/screens/aiImageGenerator/screen/aiImageGeneratorScreen.tsx
@@ -14,7 +14,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { useQuery } from '@tanstack/react-query';
 import { getAiGeneratePriceQueryOptions, getPointsQueryOptions } from '@ecency/sdk';
 import { Image as ExpoImage } from 'expo-image';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BasicHeader } from '../../../components/basicHeader';
 import { MainButton } from '../../../components/mainButton';
 import { useGenerateImageMutation } from '../../../providers/sdk/mutations';
@@ -43,6 +43,7 @@ const AiImageGeneratorScreen = () => {
   const navigation = useNavigation();
   const route = useRoute();
   const { username, code } = useAuth();
+  const insets = useSafeAreaInsets();
 
   const { onInsert, suggestedPrompt } = (route.params ?? {}) as AiImageGeneratorParams;
 
@@ -316,7 +317,10 @@ const AiImageGeneratorScreen = () => {
       <BasicHeader title={intl.formatMessage({ id: 'ai_image_generator.title' })} />
       <ScrollView
         style={styles.container}
-        contentContainerStyle={styles.scrollContent}
+        // Padding rather than a bottom edge on the SafeAreaView: the result view
+        // overflows at the portrait ratios, and this clears the home indicator
+        // without leaving a gap under the scroll area in the states that do not.
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 16 + insets.bottom }]}
         keyboardShouldPersistTaps="handled"
       >
         {_renderCostAndBalance()}

--- a/src/screens/emailDigests/screen/emailDigestsScreen.tsx
+++ b/src/screens/emailDigests/screen/emailDigestsScreen.tsx
@@ -158,7 +158,7 @@ const EmailDigestsScreen = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom']}>
+    <SafeAreaView style={styles.container}>
       <BasicHeader title={intl.formatMessage({ id: 'newsletter.screen_title' })} />
       {_renderContent()}
     </SafeAreaView>


### PR DESCRIPTION
Started from a report that the Email digests header sat under the status bar. Fixed that, then cleared the related findings the audit turned up so they do not get lost.

## 1. Email digests header under the status bar (the reported bug)

`src/screens/emailDigests/screen/emailDigestsScreen.tsx`

The root SafeAreaView passed `edges={['bottom']}`. In react-native-safe-area-context 5.6.1 an explicit `edges` array sets every unlisted edge to `'off'` (SafeAreaView.tsx: `top: edgesObj.top ?? 'off'`), so this turned the top inset off. Nothing else supplied one: MainStack sets `headerShown: false` for every route, and BasicHeader's outer element is a plain View with no padding.

Dropping the prop falls back to `defaultEdges`, all four additive. That restores the top inset and keeps the bottom inset the original code wanted.

Matches existing convention rather than adding a new one: of the 32 screens rendering BasicHeader, 21 omit `edges` and 6 pass `edges={['top']}`. This was the only one excluding top. `perksScreen.tsx:16` has the identical BasicHeader plus ScrollView shape and omits the prop.

Present since the original feature commit e8a1f9be9a.

Also renamed BasicHeader's `safeArea` style key to `headerBackground`. It applies no inset at all, only a background color, and that misnomer is plausibly how this shipped. Single internal call site, no behaviour change.

## 2. Touch targets on the two newsletter icon buttons

`newsletterPostPrompt.tsx`, `newsletterSenderInfo.tsx`

Both are a fixed 30x30, under the 44pt guideline. `IconButtonProps` documents `hitSlop` as opt-in per call site where a mis-tap is costly, and the dismiss qualifies: it persists `dismissedAt` under `digest_post_prompt_{viewer}_{type}_{target}`, so a mis-tap hides the prompt for good.

The slop is asymmetric on purpose, since symmetric slop would have made things worse:

- Dismiss uses `left: 0`. The Subscribe pill is flush against it and the icon paints later, so left slop would let it swallow Subscribe taps and dismiss the card permanently.
- Copy link uses `right: 4`, staying inside the 8pt gap before "Manage" so it cannot steal taps meant for it.

Follows the file-local constant precedent (`DISMISS_HIT_SLOP`, `CLOSE_HIT_SLOP`) and the asymmetric precedent at `upvoteButton.tsx:110`.

## 3. Generate again sat under the home indicator

`src/screens/aiImageGenerator/screen/aiImageGeneratorScreen.tsx`

Found while auditing whether the bottom-edge inconsistency across `edges={['top']}` screens was real. Five of six were already fine (settings and bookmarks pad 72, assetDetails 56, postScreen has a safe-area-aware StickyBar, editor has the docked toolbar). This one had only `padding: 16`, so the bottom control ended 21pt off the edge, inside the 34pt iOS inset and behind the Android nav bar at targetSdk 36.

It only bites when content overflows, which it does in the result state at the portrait ratios the screen offers (9:16, 3:4, 2:3): `resultImage` is `width: '100%'` with the ratio applied, so a 9:16 result on a 393pt device is ~699pt tall.

Padded the scroll content by the real inset instead of adding a bottom edge to the SafeAreaView. Adding the edge also fixes it but leaves a visible gap under the scroll area in the states that do not overflow.

## Not changed

The other five `edges={['top']}` screens. The inconsistency is per-screen handling that already works, not a bug, so a sweep would have added dead space.

## Test plan

- eslint: 0 errors, and the 2 remaining warnings are pre-existing on HEAD
- yarn typecheck: 0 errors (baseline 0)
- jest: 995 passed, 72 of 73 suites, 1 pre-existing skip
- Note for review: 1 and 3 are only visible where the inset is non-zero. A notchless simulator renders them identically before and after, so check on a notch/Dynamic Island device or Android 15/16.
