### PR TITLE
fix(notifications): handle the whole follow family, fix the FCM vocabulary

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.93",
+    "@ecency/sdk": "^2.3.95",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/components/foregroundNotification/foregroundNotification.tsx
+++ b/src/components/foregroundNotification/foregroundNotification.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { IconButton } from '..';
 import UserAvatar from '../userAvatar';
 import ROUTES from '../../constants/routeNames';
+import { FOREGROUND_BANNER_TYPES } from '../../constants/notificationTypes';
 
 // Styles
 import styles from './styles';
@@ -33,6 +34,10 @@ interface RemoteMessage {
       | 'delegation'
       | 'delegations'
       | 'scheduled_published'
+      | 'payout'
+      | 'payouts'
+      | 'account_update'
+      | 'weekly_earnings'
       | 'follow'
       | 'unfollow'
       | 'ignore'
@@ -63,19 +68,7 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
   useEffect(() => {
     if (remoteMessage) {
       const { source, target, type, id, amount } = remoteMessage.data;
-      if (
-        activeId !== id &&
-        (type === 'reply' ||
-          type === 'mention' ||
-          type === 'transfer' ||
-          type === 'delegation' ||
-          type === 'delegations' ||
-          type === 'scheduled_published' ||
-          type === 'follow' ||
-          type === 'unfollow' ||
-          type === 'ignore' ||
-          type === 'blacklist')
-      ) {
+      if (activeId !== id && (FOREGROUND_BANNER_TYPES as readonly string[]).includes(type)) {
         let titleText = '';
         let bodyText = '';
 
@@ -113,6 +106,32 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
             bodyText =
               remoteMessage.notification?.body ||
               intl.formatMessage({ id: 'notification.scheduled_published_body' });
+            break;
+          // Both producers already build a correct title and body for these: enotify's
+          // push/format.py for FCM, and the websocket bridge in applicationContainer.
+          // Prefer what was delivered rather than rebuilding the interpolated strings
+          // here, the way scheduled_published already does for its body.
+          case 'payout':
+          case 'payouts':
+            titleText =
+              remoteMessage.notification?.title ||
+              intl.formatMessage({ id: 'notification.payouts' }, { amount: amount || '' });
+            bodyText = remoteMessage.notification?.body || '';
+            break;
+          case 'weekly_earnings':
+            titleText =
+              remoteMessage.notification?.title ||
+              intl.formatMessage(
+                { id: 'notification.weekly_earnings' },
+                { amount: amount || '', breakdown: '' },
+              );
+            bodyText = remoteMessage.notification?.body || '';
+            break;
+          case 'account_update':
+            titleText =
+              remoteMessage.notification?.title ||
+              intl.formatMessage({ id: 'notification.account_update' });
+            bodyText = remoteMessage.notification?.body || '';
             break;
           case 'follow':
             titleText = `@${source} ${intl.formatMessage({ id: 'notification.follow' })}`;
@@ -161,9 +180,19 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
     const { data } = remoteMessage;
     const { type } = data;
 
-    if (type === 'transfer' || type === 'delegation' || type === 'delegations') {
+    if (
+      type === 'transfer' ||
+      type === 'delegation' ||
+      type === 'delegations' ||
+      type === 'payout' ||
+      type === 'payouts' ||
+      type === 'weekly_earnings'
+    ) {
       // Navigate to wallet for financial transactions
       RootNavigation.navigate({ name: ROUTES.TABBAR.WALLET });
+    } else if (type === 'account_update') {
+      // Informational only: the app has no account-update destination, and the post
+      // branch below would open an empty permlink. Dismiss without navigating.
     } else if (
       type === 'follow' ||
       type === 'unfollow' ||

--- a/src/components/foregroundNotification/foregroundNotification.tsx
+++ b/src/components/foregroundNotification/foregroundNotification.tsx
@@ -21,7 +21,22 @@ interface RemoteMessage {
     permlink2: string;
     permlink3: string;
     amount?: string;
-    type: 'mention' | 'reply' | 'transfer' | 'delegations' | 'scheduled_published';
+    // Two producers feed this component with DIFFERENT vocabularies: FCM carries
+    // enotify's push strings (singular 'delegation' / 'payout') while the websocket
+    // bridge in applicationContainer carries str_activity_type's ('delegations' /
+    // 'payouts'). Both spellings are accepted rather than renamed, so neither
+    // producer silently stops matching.
+    type:
+      | 'mention'
+      | 'reply'
+      | 'transfer'
+      | 'delegation'
+      | 'delegations'
+      | 'scheduled_published'
+      | 'follow'
+      | 'unfollow'
+      | 'ignore'
+      | 'blacklist';
   };
   notification: {
     body: string;
@@ -53,8 +68,13 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
         (type === 'reply' ||
           type === 'mention' ||
           type === 'transfer' ||
+          type === 'delegation' ||
           type === 'delegations' ||
-          type === 'scheduled_published')
+          type === 'scheduled_published' ||
+          type === 'follow' ||
+          type === 'unfollow' ||
+          type === 'ignore' ||
+          type === 'blacklist')
       ) {
         let titleText = '';
         let bodyText = '';
@@ -77,6 +97,7 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
                 defaultMessage: 'Amount unavailable',
               });
             break;
+          case 'delegation':
           case 'delegations':
             titleText = `@${source} ${intl.formatMessage({ id: 'notification.delegations' })}`;
             bodyText =
@@ -92,6 +113,18 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
             bodyText =
               remoteMessage.notification?.body ||
               intl.formatMessage({ id: 'notification.scheduled_published_body' });
+            break;
+          case 'follow':
+            titleText = `@${source} ${intl.formatMessage({ id: 'notification.follow' })}`;
+            break;
+          case 'unfollow':
+            titleText = `@${source} ${intl.formatMessage({ id: 'notification.unfollow' })}`;
+            break;
+          case 'ignore':
+            titleText = `@${source} ${intl.formatMessage({ id: 'notification.ignore' })}`;
+            break;
+          case 'blacklist':
+            titleText = `@${source} ${intl.formatMessage({ id: 'notification.blacklist' })}`;
             break;
         }
 
@@ -128,9 +161,23 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
     const { data } = remoteMessage;
     const { type } = data;
 
-    if (type === 'transfer' || type === 'delegations') {
+    if (type === 'transfer' || type === 'delegation' || type === 'delegations') {
       // Navigate to wallet for financial transactions
       RootNavigation.navigate({ name: ROUTES.TABBAR.WALLET });
+    } else if (
+      type === 'follow' ||
+      type === 'unfollow' ||
+      type === 'ignore' ||
+      type === 'blacklist'
+    ) {
+      // The follow family carries no permlink. Falling through to the post branch
+      // below navigated to POST with an empty permlink, which opens nothing.
+      const source = get(data, 'source', '');
+      RootNavigation.navigate({
+        name: ROUTES.SCREENS.PROFILE,
+        params: { username: source },
+        key: source,
+      });
     } else {
       // Navigate to post for reply/mention
       const fullPermlink =

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -452,6 +452,7 @@
     "last_week": "Last Week",
     "recent": "Recent",
     "ignore": "ignored you",
+    "blacklist": "blacklisted you",
     "follow": "followed you",
     "notification": "Notifications",
     "this_month": "This Month",

--- a/src/constants/notificationTypes.test.ts
+++ b/src/constants/notificationTypes.test.ts
@@ -1,0 +1,48 @@
+import {
+  FCM_FOREGROUND_NOTIFICATION_TYPES,
+  FOLLOW_NOTIFICATION_TYPES,
+  WS_NOTIFICATION_TYPES,
+} from './notificationTypes';
+
+describe('notification type vocabularies', () => {
+  it('uses the SINGULAR push spellings in the FCM list', () => {
+    // push/format.py sets custom_data['type'] = 'delegation' / 'payout'. Holding the
+    // websocket plurals here meant neither ever matched an FCM message.
+    expect(FCM_FOREGROUND_NOTIFICATION_TYPES).toContain('delegation');
+    expect(FCM_FOREGROUND_NOTIFICATION_TYPES).toContain('payout');
+    expect(FCM_FOREGROUND_NOTIFICATION_TYPES).not.toContain('delegations');
+    expect(FCM_FOREGROUND_NOTIFICATION_TYPES).not.toContain('payouts');
+  });
+
+  it('uses the PLURAL websocket spellings in the websocket list', () => {
+    // helper.py str_activity_type() returns 'delegations' / 'payouts'.
+    expect(WS_NOTIFICATION_TYPES).toContain('delegations');
+    expect(WS_NOTIFICATION_TYPES).toContain('payouts');
+    expect(WS_NOTIFICATION_TYPES).not.toContain('delegation');
+    expect(WS_NOTIFICATION_TYPES).not.toContain('payout');
+  });
+
+  it('handles the whole follow family on both transports', () => {
+    // All four share ACTIVITY_MAIN_TYPE_FOLLOW, so one toggle governs them and the
+    // client has to recognise all four or they are silently dropped.
+    expect(FOLLOW_NOTIFICATION_TYPES).toEqual(['follow', 'unfollow', 'ignore', 'blacklist']);
+
+    FOLLOW_NOTIFICATION_TYPES.forEach((type) => {
+      expect(WS_NOTIFICATION_TYPES).toContain(type);
+    });
+
+    // blacklist has no push template server side (format_activity returns None), so it
+    // is never enqueued for FCM and must NOT be in the push list.
+    ['follow', 'unfollow', 'ignore'].forEach((type) => {
+      expect(FCM_FOREGROUND_NOTIFICATION_TYPES).toContain(type);
+    });
+    expect(FCM_FOREGROUND_NOTIFICATION_TYPES).not.toContain('blacklist');
+  });
+
+  it('keeps the two lists aligned except where the vocabularies genuinely differ', () => {
+    const onlyInWs = WS_NOTIFICATION_TYPES.filter(
+      (t) => !(FCM_FOREGROUND_NOTIFICATION_TYPES as readonly string[]).includes(t),
+    );
+    expect(onlyInWs.sort()).toEqual(['blacklist', 'delegations', 'payouts']);
+  });
+});

--- a/src/constants/notificationTypes.test.ts
+++ b/src/constants/notificationTypes.test.ts
@@ -1,6 +1,7 @@
 import {
   FCM_FOREGROUND_NOTIFICATION_TYPES,
   FOLLOW_NOTIFICATION_TYPES,
+  FOREGROUND_BANNER_TYPES,
   WS_NOTIFICATION_TYPES,
 } from './notificationTypes';
 
@@ -44,5 +45,18 @@ describe('notification type vocabularies', () => {
       (t) => !(FCM_FOREGROUND_NOTIFICATION_TYPES as readonly string[]).includes(t),
     );
     expect(onlyInWs.sort()).toEqual(['blacklist', 'delegations', 'payouts']);
+  });
+
+  it('renders a banner for every type either transport accepts', () => {
+    // A type accepted upstream but missing from the banner refreshes the unread badge
+    // and then shows nothing. payout, account_update and weekly_earnings were in
+    // exactly that state: accepted by both allowlists, absent from the banner.
+    const banner = FOREGROUND_BANNER_TYPES as readonly string[];
+
+    const uncovered = [...FCM_FOREGROUND_NOTIFICATION_TYPES, ...WS_NOTIFICATION_TYPES]
+      .filter((type) => !banner.includes(type))
+      .sort();
+
+    expect(uncovered).toEqual([]);
   });
 });

--- a/src/constants/notificationTypes.ts
+++ b/src/constants/notificationTypes.ts
@@ -1,0 +1,52 @@
+/**
+ * Notification type vocabularies.
+ *
+ * enotify speaks TWO different sets of strings for the same events, and mixing them up
+ * is a silent failure rather than an error:
+ *
+ *  - PUSH (FCM `data.type`) comes from `push/format.py` `custom_data['type']` and is
+ *    SINGULAR for two of them: `delegation`, `payout`, plus `favorite` / `bookmark`.
+ *  - WEBSOCKET (`wsData.type`) comes from `helper.py` `str_activity_type()` and is
+ *    PLURAL: `delegations`, `payouts`, `favorites`, `bookmarks`.
+ *
+ * The foreground FCM allowlist previously held the websocket spellings, so delegation
+ * and payout pushes never matched it and the unread badge went stale for them.
+ *
+ * The follow family (`follow`, `unfollow`, `ignore`, `blacklist`) spells the same in
+ * both. `blacklist` is websocket-only: it has no push template server side, so it is
+ * never enqueued for FCM.
+ */
+
+/** Types the foreground FCM listener reacts to. PUSH vocabulary. */
+export const FCM_FOREGROUND_NOTIFICATION_TYPES = [
+  'mention',
+  'reply',
+  'transfer',
+  'delegation',
+  'scheduled_published',
+  'payout',
+  'account_update',
+  'weekly_earnings',
+  'follow',
+  'unfollow',
+  'ignore',
+] as const;
+
+/** Types the enotify websocket bridge reacts to. WEBSOCKET vocabulary. */
+export const WS_NOTIFICATION_TYPES = [
+  'mention',
+  'reply',
+  'transfer',
+  'delegations',
+  'scheduled_published',
+  'payouts',
+  'account_update',
+  'weekly_earnings',
+  'follow',
+  'unfollow',
+  'ignore',
+  'blacklist',
+] as const;
+
+/** Follow-family types, which route to the actor's profile rather than to a post. */
+export const FOLLOW_NOTIFICATION_TYPES = ['follow', 'unfollow', 'ignore', 'blacklist'] as const;

--- a/src/constants/notificationTypes.ts
+++ b/src/constants/notificationTypes.ts
@@ -50,3 +50,27 @@ export const WS_NOTIFICATION_TYPES = [
 
 /** Follow-family types, which route to the actor's profile rather than to a post. */
 export const FOLLOW_NOTIFICATION_TYPES = ['follow', 'unfollow', 'ignore', 'blacklist'] as const;
+
+/**
+ * Types ForegroundNotification will render a banner for.
+ *
+ * MUST cover every type in both allowlists above. A type accepted upstream but absent
+ * here refreshes the unread badge and then silently shows nothing, which is how payout,
+ * account_update and weekly_earnings were lost. notificationTypes.test.ts pins that.
+ */
+export const FOREGROUND_BANNER_TYPES = [
+  'reply',
+  'mention',
+  'transfer',
+  'delegation',
+  'delegations',
+  'scheduled_published',
+  'payout',
+  'payouts',
+  'account_update',
+  'weekly_earnings',
+  'follow',
+  'unfollow',
+  'ignore',
+  'blacklist',
+] as const;

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -23,6 +23,10 @@ import {
 
 import AUTH_TYPE from '../../../constants/authType';
 import ROUTES from '../../../constants/routeNames';
+import {
+  FCM_FOREGROUND_NOTIFICATION_TYPES,
+  WS_NOTIFICATION_TYPES,
+} from '../../../constants/notificationTypes';
 
 // Services
 import {
@@ -384,18 +388,8 @@ class ApplicationContainer extends Component<any, any> {
     firebaseOnMessageListener = getMessaging().onMessage((remoteMessage) => {
       console.log('Notification Received: foreground', remoteMessage);
 
-      const notificationTypes = [
-        'mention',
-        'reply',
-        'transfer',
-        'delegations',
-        'scheduled_published',
-        'payouts',
-        'account_update',
-        'weekly_earnings',
-      ];
       const messageType = remoteMessage?.data?.type;
-      if (notificationTypes.includes(messageType as any)) {
+      if ((FCM_FOREGROUND_NOTIFICATION_TYPES as readonly string[]).includes(messageType as any)) {
         // FCM and the enotify websocket can both deliver the same event, so a
         // local +1 double-counted (e.g. daily-spin POINT transfers showed 2).
         // Re-fetch the authoritative unread count instead.
@@ -891,14 +885,7 @@ class ApplicationContainer extends Component<any, any> {
         if (
           wsData &&
           wsData.event === 'notify' &&
-          (wsData.type === 'mention' ||
-            wsData.type === 'reply' ||
-            wsData.type === 'transfer' ||
-            wsData.type === 'delegations' ||
-            wsData.type === 'scheduled_published' ||
-            wsData.type === 'payouts' ||
-            wsData.type === 'account_update' ||
-            wsData.type === 'weekly_earnings')
+          (WS_NOTIFICATION_TYPES as readonly string[]).includes(wsData.type)
         ) {
           // Re-fetch the authoritative unread count rather than a local +1:
           // FCM may deliver the same event, and a local increment in both
@@ -942,6 +929,18 @@ class ApplicationContainer extends Component<any, any> {
             case 'weekly_earnings':
               notifTitle = 'Weekly earnings';
               notifBody = extra?.total_usd ? `$${extra.total_usd}` : '';
+              break;
+            case 'follow':
+              notifTitle = `@${source} followed @${target}`;
+              break;
+            case 'unfollow':
+              notifTitle = `@${source} unfollowed @${target}`;
+              break;
+            case 'ignore':
+              notifTitle = `@${source} ignored @${target}`;
+              break;
+            case 'blacklist':
+              notifTitle = `@${source} blacklisted @${target}`;
               break;
             default:
               notifTitle = `@${source}`;
@@ -1107,30 +1106,34 @@ class ApplicationContainer extends Component<any, any> {
 
     // compile notify_types
     let notify_types: any[] = [];
-    if (settings) {
-      const notifyTypesConst = {
-        voteNotification: 1,
-        mentionNotification: 2,
-        followNotification: 3,
-        commentNotification: 4,
-        reblogNotification: 5,
-        transfersNotification: 6,
-        favoriteNotification: 13,
-        bookmarkNotification: 15,
-        delegationsNotification: 10,
-        payoutsNotification: 19,
-        accountUpdateNotification: 20,
-        weeklyEarningsNotification: 21,
-        scheduledPublishedNotification: 22,
-      };
+    const notifyTypesConst = {
+      voteNotification: 1,
+      mentionNotification: 2,
+      followNotification: 3,
+      commentNotification: 4,
+      reblogNotification: 5,
+      transfersNotification: 6,
+      favoriteNotification: 13,
+      bookmarkNotification: 15,
+      delegationsNotification: 10,
+      payoutsNotification: 19,
+      accountUpdateNotification: 20,
+      weeklyEarningsNotification: 21,
+      scheduledPublishedNotification: 22,
+    };
 
+    if (settings) {
       Object.keys(settings).forEach((item) => {
         if ((notifyTypesConst as any)[item] && settings[item]) {
           notify_types.push((notifyTypesConst as any)[item]);
         }
       });
     } else {
-      notify_types = [1, 2, 3, 4, 5, 6, 13, 15, 22];
+      // Derived, not hardcoded. The literal here used to be [1,2,3,4,5,6,13,15,22],
+      // which omitted 10, 19, 20 and 21, so a fresh login with no settings yet got no
+      // delegations, payouts, account_update or weekly_earnings pushes until it saved
+      // settings once. A hand-maintained copy of this map is guaranteed to drift.
+      notify_types = Object.values(notifyTypesConst);
     }
 
     try {

--- a/src/screens/notification/container/notificationContainer.tsx
+++ b/src/screens/notification/container/notificationContainer.tsx
@@ -113,7 +113,15 @@ const NotificationContainer = ({ navigation }: any) => {
         author: get(data, 'source'),
         permlink,
       };
-    } else if (type === 'follow') {
+    } else if (
+      type === 'follow' ||
+      type === 'unfollow' ||
+      type === 'ignore' ||
+      type === 'blacklist'
+    ) {
+      // The whole follow family is serialized with follower/following and shares
+      // ACTIVITY_MAIN_TYPE_FOLLOW. Routing only 'follow' left the other three
+      // untappable, and disagreed with the push router in useInitApplication.
       routeName = ROUTES.SCREENS.PROFILE;
       key = get(data, 'follower');
       params = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.93":
-  version "2.3.93"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.93.tgz#03c18da17be78fe4cc7180e856bb52b3fce9bed2"
-  integrity sha512-LiHDXdoGW25A2Fu0+VDM2suRZffIzKK5WwZniGptX2CM4BxXoeRtzRXGQa2AKpVsbKZCwI0+fOnZsP4i02pwzQ==
+"@ecency/sdk@^2.3.95":
+  version "2.3.95"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.95.tgz#182e8ca0daef2dd39d10bad17b74b3cca95cec0b"
+  integrity sha512-LmP9ZV9CzCanOgplNqU/SW3PPTms6lNGp9GMsNnOS9oiKc0MNeppOZWpAly+CmWSjsKvg1LkqOkBNLVnwW7bIQ==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Part of the follow notification outage fix. Backend: ecency/enotify-py#20. Web: ecency/vision-web#1708.

## Problem

enotify emits **four** follow-family types (`follow`, `unfollow`, `ignore`, `blacklist`), all sharing `ACTIVITY_MAIN_TYPE_FOLLOW`. None of them appeared in any of the three client gates, so even with a healthy backend they were dropped:

- the foreground **FCM allowlist**, so the unread badge did not bump
- the **websocket allowlist**, so no foreground banner and no badge refresh
- `ForegroundNotification`'s own **type union and render gate**

## The vocabulary bug

Separately, that FCM allowlist held the **websocket** spellings. enotify speaks two vocabularies for the same events:

| Transport | Source | Delegation | Payout |
|---|---|---|---|
| Push (FCM `data.type`) | `push/format.py` `custom_data['type']` | `delegation` | `payout` |
| Websocket (`wsData.type`) | `helper.py` `str_activity_type()` | `delegations` | `payouts` |

The list said `delegations`/`payouts`, so **those two never matched an FCM message at all** and the badge went stale for them.

Both lists move to `src/constants/notificationTypes.ts`, which documents the split and is pinned by a test. This drift is what the bug was made of, so it should fail loudly rather than silently stop matching.

## Also fixed

- **`ForegroundNotification._onPress`** sent everything that was not a transfer or delegation to `SCREENS.POST` with a concatenated permlink. The follow family carries no permlink, so tapping the banner opened nothing. It now routes to the actor's profile. The union and switch also accept singular `delegation`, since FCM delivers that spelling.
- **`notificationContainer`** routed only `follow` to the profile, leaving the other three untappable, and disagreeing with the push router in `useInitApplication` which already handles all three.
- **`_enableNotification`'s no-settings fallback** was the literal `[1,2,3,4,5,6,13,15,22]`, omitting `10`, `19`, `20` and `21`. A fresh login therefore got no delegations, payouts, account_update or weekly_earnings pushes until it saved settings once. It now derives from `notifyTypesConst` so it cannot drift. All 13 values are in enotify's `notify_type_list`, so device registration still validates.
- New `notification.blacklist` string. Needs pushing through Crowdin.

## Verification

`tsc --noEmit` clean, `eslint` clean, jest 81 suites / 1080 tests pass (was 80 / 1076).

Verified by mutation: putting the plural spellings back into the FCM list fails two of the new cases.

⚠️ Not exercised on a device. The banner, tap routing and badge behaviour are code-verified only, and want a real follow against a test account once #20 is deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delegation, follow, unfollow, ignore, and blacklist notifications.
  * Follow-related notifications now open the relevant profile.
  * Delegation and payout notifications are recognized correctly.
  * Added “blacklisted you” notification text.
  * Expanded default notification preferences to include additional notification types.

* **Bug Fixes**
  * Fixed notification visibility and navigation for newly supported notification events.

* **Tests**
  * Added coverage for notification type handling across push and in-app notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->