### PR TITLE
SDK 2.3.99: received HP delegations from balance-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.7",
     "@ecency/render-helper": "^2.5.23",
-    "@ecency/sdk": "^2.3.97",
+    "@ecency/sdk": "^2.3.99",
     "@esteemapp/react-native-autocomplete-input": "^4.2.1",
     "@esteemapp/react-native-multi-slider": "^1.1.0",
     "@native-html/iframe-plugin": "^2.6.1",

--- a/src/screens/assetDetails/children/delegationsModal.tsx
+++ b/src/screens/assetDetails/children/delegationsModal.tsx
@@ -34,7 +34,8 @@ export enum MODES {
 interface DelegationItem {
   username: string;
   vestingShares: string;
-  timestamp: string;
+  // Absent for received delegations since SDK 2.3.99: balance-api carries no time.
+  timestamp?: string;
   isExpiring?: boolean;
 }
 
@@ -221,7 +222,7 @@ export const DelegationsModal = forwardRef(({}, ref) => {
     const value = `${vestsToHp(item.vestingShares, globalProps.hivePerMVests).toFixed(3)} HP`;
 
     if (item.isExpiring) {
-      const timeLeft = _formatTimeLeft(item.timestamp);
+      const timeLeft = item.timestamp ? _formatTimeLeft(item.timestamp) : '';
       return (
         <UserListItem
           key={item.username}
@@ -239,7 +240,9 @@ export const DelegationsModal = forwardRef(({}, ref) => {
       );
     }
 
-    const timeString = new Date(item.timestamp).toDateString();
+    // No date line when the source has none (received delegations from balance-api)
+    // rather than an "Invalid Date" under the name.
+    const timeString = item.timestamp ? new Date(item.timestamp).toDateString() : undefined;
     const subRightText =
       mode === MODES.DELEGATEED && intl.formatMessage({ id: 'wallet.tap_update' });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     url "^0.11.0"
     xss "^1.0.9"
 
-"@ecency/sdk@^2.3.97":
-  version "2.3.97"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.97.tgz#347d12c87fb17915e5e7c03ef0f12d57aa0d3b45"
-  integrity sha512-hk5fdHUVeUBP7J2SvYNw3Ml/yGMJcYSDT0kuku9ZJ++F6qDi+Plg0/t9OsLjleBVQ/cHBDCDbXCjFOT4fixYMQ==
+"@ecency/sdk@^2.3.99":
+  version "2.3.99"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.99.tgz#b45d754a834549554ba6f45007d170de5b2f1df2"
+  integrity sha512-16U2Q9X8m6KZC84dDxLkmh89m+4bnKFZ5nVGkf5reB6xNYFy2BhwoRQG0dVGlv4eBcpFE9WSeqwZvvPGsgKaNw==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Closes #3542

- `@ecency/sdk` ^2.3.97 → ^2.3.99: `getReceivedVestingSharesQueryOptions` now returns the incoming half of the HAF balance-api account delegations (ecency/vision-web#1724), same shape, largest first. The installed dist has no reference to the old `received-vesting` endpoint.
- Delegations modal: `DelegationItem.timestamp` is optional; a received row, which has no time from balance-api, shows no date line instead of "Invalid Date". Expiring rows still format their time left; outgoing rows still show their delegation date.

Gates: eslint clean, typecheck 0 errors, jest 1085 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid date displays in delegation details when timestamp information is unavailable.
  - Expiring delegations now show an empty remaining-time value when no timestamp is provided.

- **Maintenance**
  - Updated the Ecency SDK dependency to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->