### PR TITLE
Deep link: ecency://auth-request signs the user in to another app

### DIFF
--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1125,7 +1125,11 @@
   "deep_link": {
     "no_existing_post": "No existing post",
     "invalid_link": "Url is invalid, you may try again with valid url or try opening it in web browser",
-    "no_existing_user": "No existing user"
+    "no_existing_user": "No existing user",
+    "posting_key_request": "{requester} is requesting the posting private key for @{username}.\n\nOnly continue if you trust this request.",
+    "posting_key_request_unnamed": "Another application is requesting the posting private key for @{username}.\n\nOnly continue if you trust this request.",
+    "auth_request_as_user": "{requester} wants to sign you in as @{username}.\n\nOnly your username and a sign-in proof are shared. The proof cannot post, vote or spend from your account, and no key leaves Ecency.",
+    "auth_request_as_current": "{requester} wants to sign you in with your Ecency account.\n\nOnly your username and a sign-in proof are shared. The proof cannot post, vote or spend from your account, and no key leaves Ecency."
   },
   "payout": {
     "breakdown": "Breakdown",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1128,8 +1128,8 @@
     "no_existing_user": "No existing user",
     "posting_key_request": "{requester} is requesting the posting private key for @{username}.\n\nOnly continue if you trust this request.",
     "posting_key_request_unnamed": "Another application is requesting the posting private key for @{username}.\n\nOnly continue if you trust this request.",
-    "auth_request_as_user": "{requester} wants to sign you in as @{username}.\n\nOnly your username and a sign-in proof are shared. The proof cannot post, vote or spend from your account, and no key leaves Ecency.",
-    "auth_request_as_current": "{requester} wants to sign you in with your Ecency account.\n\nOnly your username and a sign-in proof are shared. The proof cannot post, vote or spend from your account, and no key leaves Ecency."
+    "auth_request_as_user": "{requester} wants to sign you in as @{username}.\n\nOnly your username and a sign-in proof are shared. No key leaves Ecency.",
+    "auth_request_as_current": "{requester} wants to sign you in with your Ecency account.\n\nOnly your username and a sign-in proof are shared. No key leaves Ecency."
   },
   "payout": {
     "breakdown": "Breakdown",

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -28,8 +28,13 @@ import authType from '../constants/authType';
 import { getUserDataWithUsername } from '../storage/storage';
 import { decryptKey } from '../utils/crypto';
 import { loginWithAuthTransfer } from '../providers/hive/auth';
-import { isAuthRequestDeeplink, parseAuthRequestDeeplink } from '../utils/authRequest';
-import { makeHsCode } from '../utils/hive-signer-helper';
+import {
+  callbackAudience,
+  isAuthRequestDeeplink,
+  isHiveAccountName,
+  parseAuthRequestDeeplink,
+} from '../utils/authRequest';
+import { makeHsLoginProof } from '../utils/hive-signer-helper';
 import {
   selectCurrentAccount,
   selectPin,
@@ -346,18 +351,22 @@ export const useLinkProcessor = (onClose?: () => void) => {
 
   const _confirmPostingKeyShare = (username: string, requesterLabel: string) =>
     _confirmShare(
-      `${
-        requesterLabel
-          ? `${requesterLabel} is requesting the posting private key for @${username}.`
-          : `Another application is requesting the posting private key for @${username}.`
-      }\n\nOnly continue if you trust this request.`,
+      intl.formatMessage(
+        {
+          id: requesterLabel
+            ? 'deep_link.posting_key_request'
+            : 'deep_link.posting_key_request_unnamed',
+        },
+        { requester: requesterLabel, username },
+      ),
     );
 
-  // ecency://auth-request: sign the user in to another app with a login proof,
-  // a code signed here with the posting key, never a key and never the stored
-  // HiveSigner token. See utils/authRequest.ts for the contract. The user
-  // confirms before any answer leaves, the requester shown is the callback
-  // itself, and refusals name no account.
+  // ecency://auth-request: sign the user in to another app with a sign-in
+  // proof signed here. Never a key, never the stored HiveSigner token, and
+  // never a HiveSigner code, which Ecency's exchange would turn into tokens.
+  // See utils/authRequest.ts for the contract. The user confirms before any
+  // answer leaves, the requester shown is the callback itself, and refusals
+  // name no account.
   const _handleEcencyAuthRequestDeeplink = async (deeplink: string) => {
     onClose && onClose();
     const request = parseAuthRequestDeeplink(deeplink);
@@ -370,9 +379,16 @@ export const useLinkProcessor = (onClose?: () => void) => {
       _openCallback(callback, requestId, { status: 'error', error });
     try {
       const requesterLabel = _getRequesterLabel(callback);
-      const who = request.username ? `as @${request.username}` : 'with your Ecency account';
       const userConfirmed = await _confirmShare(
-        `${requesterLabel} wants to sign you in ${who}.\n\nOnly your username and a fresh login proof are shared. No key leaves Ecency.`,
+        request.username
+          ? intl.formatMessage(
+              { id: 'deep_link.auth_request_as_user' },
+              { requester: requesterLabel, username: request.username },
+            )
+          : intl.formatMessage(
+              { id: 'deep_link.auth_request_as_current' },
+              { requester: requesterLabel },
+            ),
       );
       if (!userConfirmed) {
         await refuse('user_cancelled');
@@ -422,8 +438,11 @@ export const useLinkProcessor = (onClose?: () => void) => {
         await refuse('pin_required');
         return;
       }
-      const postingKey = userData.postingKey ? decryptKey(userData.postingKey, digitPinCode) : '';
-      if (!postingKey) {
+      // The posting key signs the proof. An account signed in with its active
+      // key alone holds only that one, and a proof it signs verifies the same.
+      const encryptedKey = userData.postingKey || userData.activeKey;
+      const signingKey = encryptedKey ? decryptKey(encryptedKey, digitPinCode) : '';
+      if (!signingKey) {
         // Signed in through HiveSigner or HiveAuth: no key here to sign a fresh
         // proof with, and the stored token is a signing credential, not a proof.
         await refuse('use_hivesigner');
@@ -432,7 +451,11 @@ export const useLinkProcessor = (onClose?: () => void) => {
       await _openCallback(callback, requestId, {
         status: 'success',
         username,
-        code: makeHsCode(username, PrivateKey.fromString(postingKey)),
+        code: makeHsLoginProof(
+          username,
+          PrivateKey.fromString(signingKey),
+          callbackAudience(callback),
+        ),
       });
     } catch (error) {
       console.warn('Failed to complete ecency auth-request', error);
@@ -458,7 +481,8 @@ export const useLinkProcessor = (onClose?: () => void) => {
       }
 
       const normalizedUsername = usernameParam.replace(/^@/, '').trim().toLowerCase();
-      if (!normalizedUsername) {
+      // Only a Hive account name reaches the confirmation below.
+      if (!isHiveAccountName(normalizedUsername)) {
         _showInvalidAlert();
         return;
       }

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -6,6 +6,7 @@ import { get } from 'lodash';
 import { useIntl } from 'react-intl';
 import * as hiveuri from 'hive-uri';
 import EStyleSheet from 'react-native-extended-stylesheet';
+import { PrivateKey } from '@ecency/sdk';
 import { toastNotification } from '../redux/actions/uiAction';
 import {
   handleHiveUriOperation,
@@ -27,6 +28,8 @@ import authType from '../constants/authType';
 import { getUserDataWithUsername } from '../storage/storage';
 import { decryptKey } from '../utils/crypto';
 import { loginWithAuthTransfer } from '../providers/hive/auth';
+import { isAuthRequestDeeplink, parseAuthRequestDeeplink } from '../utils/authRequest';
+import { makeHsCode } from '../utils/hive-signer-helper';
 import {
   selectCurrentAccount,
   selectPin,
@@ -345,6 +348,105 @@ export const useLinkProcessor = (onClose?: () => void) => {
       );
     });
 
+  const _confirmSignInShare = (username: string, requesterLabel: string) =>
+    new Promise<boolean>((resolve) => {
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.confirm' }),
+        `${requesterLabel} wants to sign you in as @${username}.\n\nOnly your username and a login proof are shared. No key leaves Ecency.`,
+        [
+          {
+            text: intl.formatMessage({ id: 'qr.cancel' }),
+            style: 'cancel',
+            onPress: () => resolve(false),
+          },
+          {
+            text: intl.formatMessage({ id: 'qr.approve' }),
+            onPress: () => resolve(true),
+          },
+        ],
+        { cancelable: false },
+      );
+    });
+
+  // ecency://auth-request: sign the user in to another app with a login proof
+  // (a code signed with the posting key, or the account's HiveSigner token),
+  // never a key. See utils/authRequest.ts for the contract.
+  const _handleEcencyAuthRequestDeeplink = async (deeplink: string) => {
+    try {
+      onClose && onClose();
+      const request = parseAuthRequestDeeplink(deeplink);
+      if (!request) {
+        _showInvalidAlert();
+        return;
+      }
+      const { callback, requestId } = request;
+      const requesterLabel =
+        request.app !== 'another app' ? request.app : _getRequesterLabel(callback);
+      const currentAccountName = (currentAccount?.name || '').toLowerCase();
+      const username = request.username || currentAccountName;
+      const isKnownAccount =
+        !!username &&
+        (currentAccountName === username ||
+          otherAccounts?.some(
+            (account: any) => (account?.username || '').toLowerCase() === username,
+          ));
+      const responsePayload: Record<string, string> = { status: 'error' };
+      if (username) {
+        responsePayload.username = username;
+      }
+      if (!isLoggedIn || !isKnownAccount) {
+        responsePayload.error = 'not_logged_in';
+        responsePayload.message = username
+          ? `Username ${username} is not logged in on Ecency.`
+          : 'No account is logged in on Ecency.';
+        await _openCallback(callback, requestId, responsePayload);
+        return;
+      }
+      const userData = await _getStoredUserData(username);
+      if (!userData) {
+        responsePayload.error = 'not_found';
+        responsePayload.message = `Username ${username} is not logged in on Ecency.`;
+        await _openCallback(callback, requestId, responsePayload);
+        return;
+      }
+      const digitPinCode = pinCode ? getDigitPinCode(pinCode) : '';
+      if (!digitPinCode) {
+        responsePayload.error = 'pin_required';
+        responsePayload.message = `Unable to unlock stored credentials for ${username}.`;
+        await _openCallback(callback, requestId, responsePayload);
+        return;
+      }
+      const userConfirmed = await _confirmSignInShare(username, requesterLabel);
+      if (!userConfirmed) {
+        responsePayload.error = 'user_cancelled';
+        responsePayload.message = `User declined to sign in to ${requesterLabel}.`;
+        await _openCallback(callback, requestId, responsePayload);
+        return;
+      }
+      const successPayload: Record<string, string> = { status: 'success', username };
+      const postingKey = userData.postingKey ? decryptKey(userData.postingKey, digitPinCode) : '';
+      if (postingKey) {
+        // A key-based account: a fresh login code, signed here, the key stays here.
+        successPayload.code = makeHsCode(username, PrivateKey.fromString(postingKey));
+      } else {
+        const accessToken = userData.accessToken
+          ? decryptKey(userData.accessToken, digitPinCode)
+          : '';
+        if (!accessToken) {
+          responsePayload.error = 'credential_unavailable';
+          responsePayload.message = `No login proof is available for ${username} on this device.`;
+          await _openCallback(callback, requestId, responsePayload);
+          return;
+        }
+        successPayload.access_token = accessToken;
+      }
+      await _openCallback(callback, requestId, successPayload);
+    } catch (error) {
+      console.warn('Failed to handle ecency auth-request deeplink', error);
+      _showInvalidAlert();
+    }
+  };
+
   const _handleEcencyLoginDeeplink = async (deeplink: string) => {
     try {
       onClose && onClose();
@@ -533,6 +635,10 @@ export const useLinkProcessor = (onClose?: () => void) => {
   const handleLink = (deeplink: string) => {
     if (_isEcencyAuthTransferDeeplink(deeplink)) {
       _handleEcencyAuthTransferDeeplink(deeplink);
+      return;
+    }
+    if (isAuthRequestDeeplink(deeplink)) {
+      _handleEcencyAuthRequestDeeplink(deeplink);
       return;
     }
 

--- a/src/hooks/useLinkProcessor.tsx
+++ b/src/hooks/useLinkProcessor.tsx
@@ -324,126 +324,119 @@ export const useLinkProcessor = (onClose?: () => void) => {
     }
   };
 
+  const _confirmShare = (message: string) =>
+    new Promise<boolean>((resolve) => {
+      Alert.alert(
+        intl.formatMessage({ id: 'alert.confirm' }),
+        message,
+        [
+          {
+            text: intl.formatMessage({ id: 'qr.cancel' }),
+            style: 'cancel',
+            onPress: () => resolve(false),
+          },
+          {
+            text: intl.formatMessage({ id: 'qr.approve' }),
+            onPress: () => resolve(true),
+          },
+        ],
+        { cancelable: false },
+      );
+    });
+
   const _confirmPostingKeyShare = (username: string, requesterLabel: string) =>
-    new Promise<boolean>((resolve) => {
-      const requesterText = requesterLabel
-        ? `${requesterLabel} is requesting the posting private key for @${username}.`
-        : `Another application is requesting the posting private key for @${username}.`;
+    _confirmShare(
+      `${
+        requesterLabel
+          ? `${requesterLabel} is requesting the posting private key for @${username}.`
+          : `Another application is requesting the posting private key for @${username}.`
+      }\n\nOnly continue if you trust this request.`,
+    );
 
-      Alert.alert(
-        intl.formatMessage({ id: 'alert.confirm' }),
-        `${requesterText}\n\nOnly continue if you trust this request.`,
-        [
-          {
-            text: intl.formatMessage({ id: 'qr.cancel' }),
-            style: 'cancel',
-            onPress: () => resolve(false),
-          },
-          {
-            text: intl.formatMessage({ id: 'qr.approve' }),
-            onPress: () => resolve(true),
-          },
-        ],
-        { cancelable: false },
-      );
-    });
-
-  const _confirmSignInShare = (username: string, requesterLabel: string) =>
-    new Promise<boolean>((resolve) => {
-      Alert.alert(
-        intl.formatMessage({ id: 'alert.confirm' }),
-        `${requesterLabel} wants to sign you in as @${username}.\n\nOnly your username and a login proof are shared. No key leaves Ecency.`,
-        [
-          {
-            text: intl.formatMessage({ id: 'qr.cancel' }),
-            style: 'cancel',
-            onPress: () => resolve(false),
-          },
-          {
-            text: intl.formatMessage({ id: 'qr.approve' }),
-            onPress: () => resolve(true),
-          },
-        ],
-        { cancelable: false },
-      );
-    });
-
-  // ecency://auth-request: sign the user in to another app with a login proof
-  // (a code signed with the posting key, or the account's HiveSigner token),
-  // never a key. See utils/authRequest.ts for the contract.
+  // ecency://auth-request: sign the user in to another app with a login proof,
+  // a code signed here with the posting key, never a key and never the stored
+  // HiveSigner token. See utils/authRequest.ts for the contract. The user
+  // confirms before any answer leaves, the requester shown is the callback
+  // itself, and refusals name no account.
   const _handleEcencyAuthRequestDeeplink = async (deeplink: string) => {
+    onClose && onClose();
+    const request = parseAuthRequestDeeplink(deeplink);
+    if (!request) {
+      _showInvalidAlert();
+      return;
+    }
+    const { callback, requestId } = request;
+    const refuse = (error: string) =>
+      _openCallback(callback, requestId, { status: 'error', error });
     try {
-      onClose && onClose();
-      const request = parseAuthRequestDeeplink(deeplink);
-      if (!request) {
-        _showInvalidAlert();
+      const requesterLabel = _getRequesterLabel(callback);
+      const who = request.username ? `as @${request.username}` : 'with your Ecency account';
+      const userConfirmed = await _confirmShare(
+        `${requesterLabel} wants to sign you in ${who}.\n\nOnly your username and a fresh login proof are shared. No key leaves Ecency.`,
+      );
+      if (!userConfirmed) {
+        await refuse('user_cancelled');
         return;
       }
-      const { callback, requestId } = request;
-      const requesterLabel =
-        request.app !== 'another app' ? request.app : _getRequesterLabel(callback);
+      if (isPinCodeOpen) {
+        RootNavigation.navigate({
+          name: ROUTES.SCREENS.PINCODE,
+          params: { callback: () => _completeAuthRequest(callback, requestId, request.username) },
+        });
+        return;
+      }
+      await _completeAuthRequest(callback, requestId, request.username);
+    } catch (error) {
+      console.warn('Failed to handle ecency auth-request deeplink', error);
+      await refuse('internal_error');
+    }
+  };
+
+  const _completeAuthRequest = async (
+    callback: string,
+    requestId: string | null,
+    requested: string | null,
+  ) => {
+    const refuse = (error: string) =>
+      _openCallback(callback, requestId, { status: 'error', error });
+    try {
       const currentAccountName = (currentAccount?.name || '').toLowerCase();
-      const username = request.username || currentAccountName;
+      const username = requested || currentAccountName;
       const isKnownAccount =
         !!username &&
         (currentAccountName === username ||
           otherAccounts?.some(
             (account: any) => (account?.username || '').toLowerCase() === username,
           ));
-      const responsePayload: Record<string, string> = { status: 'error' };
-      if (username) {
-        responsePayload.username = username;
-      }
       if (!isLoggedIn || !isKnownAccount) {
-        responsePayload.error = 'not_logged_in';
-        responsePayload.message = username
-          ? `Username ${username} is not logged in on Ecency.`
-          : 'No account is logged in on Ecency.';
-        await _openCallback(callback, requestId, responsePayload);
+        await refuse('not_logged_in');
         return;
       }
       const userData = await _getStoredUserData(username);
       if (!userData) {
-        responsePayload.error = 'not_found';
-        responsePayload.message = `Username ${username} is not logged in on Ecency.`;
-        await _openCallback(callback, requestId, responsePayload);
+        await refuse('not_logged_in');
         return;
       }
       const digitPinCode = pinCode ? getDigitPinCode(pinCode) : '';
       if (!digitPinCode) {
-        responsePayload.error = 'pin_required';
-        responsePayload.message = `Unable to unlock stored credentials for ${username}.`;
-        await _openCallback(callback, requestId, responsePayload);
+        await refuse('pin_required');
         return;
       }
-      const userConfirmed = await _confirmSignInShare(username, requesterLabel);
-      if (!userConfirmed) {
-        responsePayload.error = 'user_cancelled';
-        responsePayload.message = `User declined to sign in to ${requesterLabel}.`;
-        await _openCallback(callback, requestId, responsePayload);
-        return;
-      }
-      const successPayload: Record<string, string> = { status: 'success', username };
       const postingKey = userData.postingKey ? decryptKey(userData.postingKey, digitPinCode) : '';
-      if (postingKey) {
-        // A key-based account: a fresh login code, signed here, the key stays here.
-        successPayload.code = makeHsCode(username, PrivateKey.fromString(postingKey));
-      } else {
-        const accessToken = userData.accessToken
-          ? decryptKey(userData.accessToken, digitPinCode)
-          : '';
-        if (!accessToken) {
-          responsePayload.error = 'credential_unavailable';
-          responsePayload.message = `No login proof is available for ${username} on this device.`;
-          await _openCallback(callback, requestId, responsePayload);
-          return;
-        }
-        successPayload.access_token = accessToken;
+      if (!postingKey) {
+        // Signed in through HiveSigner or HiveAuth: no key here to sign a fresh
+        // proof with, and the stored token is a signing credential, not a proof.
+        await refuse('use_hivesigner');
+        return;
       }
-      await _openCallback(callback, requestId, successPayload);
+      await _openCallback(callback, requestId, {
+        status: 'success',
+        username,
+        code: makeHsCode(username, PrivateKey.fromString(postingKey)),
+      });
     } catch (error) {
-      console.warn('Failed to handle ecency auth-request deeplink', error);
-      _showInvalidAlert();
+      console.warn('Failed to complete ecency auth-request', error);
+      await refuse('internal_error');
     }
   };
 

--- a/src/utils/authRequest.test.ts
+++ b/src/utils/authRequest.test.ts
@@ -51,11 +51,22 @@ describe('auth-request deeplink', () => {
     expect(parseAuthRequestDeeplink('garbage')).toBeNull();
   });
 
-  it('judges callbacks by scheme', () => {
+  it('allows only https and registered app schemes', () => {
     expect(isAcceptableCallback('honeyback://hive')).toBe(true);
+    expect(isAcceptableCallback('HONEYBACK://hive')).toBe(true);
     expect(isAcceptableCallback('https://example.com/cb')).toBe(true);
-    expect(isAcceptableCallback('http://example.com/cb')).toBe(false);
-    expect(isAcceptableCallback('data:text/html,x')).toBe(false);
-    expect(isAcceptableCallback('nope')).toBe(false);
+    [
+      'http://example.com/cb',
+      'ftp://example.com/cb',
+      'intent://collect#Intent;scheme=evil;end',
+      'mailto:someone@example.com',
+      'tel:+123',
+      'data:text/html,x',
+      'javascript:alert(1)',
+      'unregistered://app',
+      'nope',
+    ].forEach((rejected) => {
+      expect(isAcceptableCallback(rejected)).toBe(false);
+    });
   });
 });

--- a/src/utils/authRequest.test.ts
+++ b/src/utils/authRequest.test.ts
@@ -1,0 +1,44 @@
+import { isAuthRequestDeeplink, parseAuthRequestDeeplink } from './authRequest';
+
+describe('auth-request deeplink', () => {
+  it('recognises only ecency://auth-request', () => {
+    expect(isAuthRequestDeeplink('ecency://auth-request?callback=honeyback%3A%2F%2Fhive')).toBe(
+      true,
+    );
+    expect(isAuthRequestDeeplink('ECENCY://Auth-Request?callback=x')).toBe(true);
+    expect(isAuthRequestDeeplink('ecency://login?callback=x')).toBe(false);
+    expect(isAuthRequestDeeplink('https://ecency.com/auth-request')).toBe(false);
+    expect(isAuthRequestDeeplink('not a url')).toBe(false);
+  });
+
+  it('parses the callback, request id, app and optional username', () => {
+    const r = parseAuthRequestDeeplink(
+      'ecency://auth-request?app=ecency.app&callback=honeyback%3A%2F%2Fhive&request_id=r1&username=%40Good-Karma',
+    );
+    expect(r).toEqual({
+      callback: 'honeyback://hive',
+      requestId: 'r1',
+      username: 'good-karma',
+      app: 'ecency.app',
+    });
+  });
+
+  it('accepts redirect_uri and return_url for the callback and defaults the rest', () => {
+    expect(
+      parseAuthRequestDeeplink('ecency://auth-request?redirect_uri=honeyback%3A%2F%2Fhive'),
+    ).toEqual({
+      callback: 'honeyback://hive',
+      requestId: null,
+      username: null,
+      app: 'another app',
+    });
+    expect(parseAuthRequestDeeplink('ecency://auth-request?return_url=x%3A%2F%2Fy')?.callback).toBe(
+      'x://y',
+    );
+  });
+
+  it('needs a callback', () => {
+    expect(parseAuthRequestDeeplink('ecency://auth-request?request_id=r1')).toBeNull();
+    expect(parseAuthRequestDeeplink('garbage')).toBeNull();
+  });
+});

--- a/src/utils/authRequest.test.ts
+++ b/src/utils/authRequest.test.ts
@@ -51,19 +51,20 @@ describe('auth-request deeplink', () => {
     expect(parseAuthRequestDeeplink('garbage')).toBeNull();
   });
 
-  it('allows only https and registered app schemes', () => {
+  it('rejects transports, page schemes, messaging handlers and intents', () => {
     expect(isAcceptableCallback('honeyback://hive')).toBe(true);
-    expect(isAcceptableCallback('HONEYBACK://hive')).toBe(true);
+    expect(isAcceptableCallback('anyapp://callback')).toBe(true);
     expect(isAcceptableCallback('https://example.com/cb')).toBe(true);
     [
       'http://example.com/cb',
       'ftp://example.com/cb',
+      'ws://example.com/cb',
+      'wss://example.com/cb',
       'intent://collect#Intent;scheme=evil;end',
       'mailto:someone@example.com',
       'tel:+123',
       'data:text/html,x',
       'javascript:alert(1)',
-      'unregistered://app',
       'nope',
     ].forEach((rejected) => {
       expect(isAcceptableCallback(rejected)).toBe(false);

--- a/src/utils/authRequest.test.ts
+++ b/src/utils/authRequest.test.ts
@@ -1,44 +1,61 @@
-import { isAuthRequestDeeplink, parseAuthRequestDeeplink } from './authRequest';
+import {
+  isAcceptableCallback,
+  isAuthRequestDeeplink,
+  parseAuthRequestDeeplink,
+} from './authRequest';
 
 describe('auth-request deeplink', () => {
   it('recognises only ecency://auth-request', () => {
     expect(isAuthRequestDeeplink('ecency://auth-request?callback=honeyback%3A%2F%2Fhive')).toBe(
       true,
     );
-    expect(isAuthRequestDeeplink('ECENCY://Auth-Request?callback=x')).toBe(true);
+    expect(isAuthRequestDeeplink('ECENCY://Auth-Request?callback=x%3A%2F%2Fy')).toBe(true);
     expect(isAuthRequestDeeplink('ecency://login?callback=x')).toBe(false);
     expect(isAuthRequestDeeplink('https://ecency.com/auth-request')).toBe(false);
     expect(isAuthRequestDeeplink('not a url')).toBe(false);
   });
 
-  it('parses the callback, request id, app and optional username', () => {
+  it('parses the callback, request id and optional username', () => {
     const r = parseAuthRequestDeeplink(
-      'ecency://auth-request?app=ecency.app&callback=honeyback%3A%2F%2Fhive&request_id=r1&username=%40Good-Karma',
+      'ecency://auth-request?app=Trusted&callback=honeyback%3A%2F%2Fhive&request_id=r1&username=%40Good-Karma',
     );
-    expect(r).toEqual({
-      callback: 'honeyback://hive',
-      requestId: 'r1',
-      username: 'good-karma',
-      app: 'ecency.app',
-    });
+    expect(r).toEqual({ callback: 'honeyback://hive', requestId: 'r1', username: 'good-karma' });
   });
 
-  it('accepts redirect_uri and return_url for the callback and defaults the rest', () => {
+  it('accepts redirect_uri and return_url for the callback', () => {
     expect(
       parseAuthRequestDeeplink('ecency://auth-request?redirect_uri=honeyback%3A%2F%2Fhive'),
     ).toEqual({
       callback: 'honeyback://hive',
       requestId: null,
       username: null,
-      app: 'another app',
     });
     expect(parseAuthRequestDeeplink('ecency://auth-request?return_url=x%3A%2F%2Fy')?.callback).toBe(
       'x://y',
     );
   });
 
-  it('needs a callback', () => {
+  it('needs a callback the answer may go to', () => {
     expect(parseAuthRequestDeeplink('ecency://auth-request?request_id=r1')).toBeNull();
+    expect(
+      parseAuthRequestDeeplink('ecency://auth-request?callback=http%3A%2F%2Fevil.example%2Fc'),
+    ).toBeNull();
+    expect(
+      parseAuthRequestDeeplink('ecency://auth-request?callback=javascript%3Aalert(1)'),
+    ).toBeNull();
+    expect(
+      parseAuthRequestDeeplink(
+        'ecency://auth-request?callback=https%3A%2F%2Fgames-api.ecency.com%2Fv1%2Fhive%2Fcallback',
+      )?.callback,
+    ).toBe('https://games-api.ecency.com/v1/hive/callback');
     expect(parseAuthRequestDeeplink('garbage')).toBeNull();
+  });
+
+  it('judges callbacks by scheme', () => {
+    expect(isAcceptableCallback('honeyback://hive')).toBe(true);
+    expect(isAcceptableCallback('https://example.com/cb')).toBe(true);
+    expect(isAcceptableCallback('http://example.com/cb')).toBe(false);
+    expect(isAcceptableCallback('data:text/html,x')).toBe(false);
+    expect(isAcceptableCallback('nope')).toBe(false);
   });
 });

--- a/src/utils/authRequest.test.ts
+++ b/src/utils/authRequest.test.ts
@@ -1,6 +1,8 @@
 import {
+  callbackAudience,
   isAcceptableCallback,
   isAuthRequestDeeplink,
+  isHiveAccountName,
   parseAuthRequestDeeplink,
 } from './authRequest';
 
@@ -51,7 +53,32 @@ describe('auth-request deeplink', () => {
     expect(parseAuthRequestDeeplink('garbage')).toBeNull();
   });
 
-  it('rejects transports, page schemes, messaging handlers and intents', () => {
+  it('takes a username only when it is a Hive account name', () => {
+    const base = 'ecency://auth-request?callback=honeyback%3A%2F%2Fhive';
+    expect(parseAuthRequestDeeplink(`${base}&username=ecency.waves`)?.username).toBe(
+      'ecency.waves',
+    );
+    expect(parseAuthRequestDeeplink(`${base}&username=`)?.username).toBeNull();
+    // Text a caller could aim at the confirmation dialog invalidates the request.
+    expect(
+      parseAuthRequestDeeplink(`${base}&username=you%0A%0AEcency%20verified%20this%20app`),
+    ).toBeNull();
+    expect(parseAuthRequestDeeplink(`${base}&username=ab`)).toBeNull();
+    expect(parseAuthRequestDeeplink(`${base}&username=%40you%20there`)).toBeNull();
+  });
+
+  it('knows a Hive account name', () => {
+    ['good-karma', 'ecency.waves', 'abc', 'a1-b2.c3d'].forEach((ok) => {
+      expect(isHiveAccountName(ok)).toBe(true);
+    });
+    ['', 'ab', 'Good-Karma', '1abc', 'a'.repeat(17), 'you\n\nverified', 'you there'].forEach(
+      (bad) => {
+        expect(isHiveAccountName(bad)).toBe(false);
+      },
+    );
+  });
+
+  it('rejects transports, page schemes, messaging handlers, intents and our own schemes', () => {
     expect(isAcceptableCallback('honeyback://hive')).toBe(true);
     expect(isAcceptableCallback('anyapp://callback')).toBe(true);
     expect(isAcceptableCallback('https://example.com/cb')).toBe(true);
@@ -65,9 +92,19 @@ describe('auth-request deeplink', () => {
       'tel:+123',
       'data:text/html,x',
       'javascript:alert(1)',
+      'ecency://login?callback=evil%3A%2F%2Fx',
+      'hive://sign/op/abc',
       'nope',
     ].forEach((rejected) => {
       expect(isAcceptableCallback(rejected)).toBe(false);
     });
+  });
+
+  it('names the audience of a proof after the callback', () => {
+    expect(callbackAudience('honeyback://hive')).toBe('honeyback://hive');
+    expect(callbackAudience('HONEYBACK://Hive/link?x=1')).toBe('honeyback://hive');
+    expect(callbackAudience('https://games-api.ecency.com/v1/hive/callback?x=1')).toBe(
+      'https://games-api.ecency.com',
+    );
   });
 });

--- a/src/utils/authRequest.ts
+++ b/src/utils/authRequest.ts
@@ -1,21 +1,24 @@
 // ecency://auth-request: another app asks Ecency to sign the user in and
 // come back on its callback with the username and a login proof, never a key.
 //
-//   ecency://auth-request?callback=<url>&request_id=<id>[&username=<u>][&app=<name>]
+//   ecency://auth-request?callback=<url>&request_id=<id>[&username=<u>]
 //
 // Success:  <callback>?status=success&username=<u>&code=<login code>&request_id=<id>
-//       or  <callback>?status=success&username=<u>&access_token=<HiveSigner token>&request_id=<id>
-// Refusal:  <callback>?status=error&error=<code>&message=<text>&request_id=<id>
+// Refusal:  <callback>?status=error&error=<code>&request_id=<id>
 //
-// The code is what makeHsCode builds (signed for ecency.app with the posting
-// key); accounts signed in through HiveSigner or HiveAuth hand over their
-// HiveSigner access token instead. Both verify the HiveSigner way.
+// The code is what makeHsCode builds: a fresh message signed with the posting
+// key for ecency.app, verifiable the HiveSigner way and good for nothing else.
+// Accounts that hold no posting key here (signed in through HiveSigner or
+// HiveAuth) are answered with use_hivesigner: their stored token is a
+// reusable signing credential and is never shared. The user confirms before
+// any answer, and refusals name no account, so a caller cannot learn which
+// accounts live on the device. The requester shown to the user is the
+// callback itself; nothing the caller says about itself is displayed.
 
 export interface AuthRequest {
   callback: string;
   requestId: string | null;
   username: string | null; // a specific account, or the current one when absent
-  app: string; // who is asking, for the confirmation only
 }
 
 export const isAuthRequestDeeplink = (deeplink: string): boolean => {
@@ -29,6 +32,18 @@ export const isAuthRequestDeeplink = (deeplink: string): boolean => {
   }
 };
 
+// / A callback the answer may be sent to: an app's own scheme or https, never
+// / plain http or anything that runs in a page.
+export const isAcceptableCallback = (callback: string): boolean => {
+  try {
+    const url = new URL(callback);
+    const protocol = url.protocol.toLowerCase();
+    return !['http:', 'javascript:', 'data:', 'file:', 'blob:', 'about:'].includes(protocol);
+  } catch (err) {
+    return false;
+  }
+};
+
 export const parseAuthRequestDeeplink = (deeplink: string): AuthRequest | null => {
   try {
     const url = new URL(deeplink);
@@ -36,7 +51,7 @@ export const parseAuthRequestDeeplink = (deeplink: string): AuthRequest | null =
       url.searchParams.get('callback') ||
       url.searchParams.get('redirect_uri') ||
       url.searchParams.get('return_url');
-    if (!callback) {
+    if (!callback || !isAcceptableCallback(callback)) {
       return null;
     }
     const username = (url.searchParams.get('username') || '')
@@ -47,7 +62,6 @@ export const parseAuthRequestDeeplink = (deeplink: string): AuthRequest | null =
       callback,
       requestId: url.searchParams.get('request_id'),
       username: username || null,
-      app: (url.searchParams.get('app') || '').trim() || 'another app',
     };
   } catch (err) {
     return null;

--- a/src/utils/authRequest.ts
+++ b/src/utils/authRequest.ts
@@ -13,7 +13,8 @@
 // reusable signing credential and is never shared. The user confirms before
 // any answer, and refusals name no account, so a caller cannot learn which
 // accounts live on the device. The requester shown to the user is the
-// callback itself; nothing the caller says about itself is displayed.
+// callback itself; nothing the caller says about itself is displayed, and the
+// callback must be https or the scheme of a registered app.
 
 export interface AuthRequest {
   callback: string;
@@ -32,13 +33,16 @@ export const isAuthRequestDeeplink = (deeplink: string): boolean => {
   }
 };
 
-// / A callback the answer may be sent to: an app's own scheme or https, never
-// / plain http or anything that runs in a page.
+// The apps that may ask: their own URL schemes. Adding an integrator is a
+// line here, and nothing else on a device can be handed a login proof.
+export const REGISTERED_APP_SCHEMES = ['honeyback'];
+
+// A callback the answer may be sent to: https, or a registered app's scheme.
 export const isAcceptableCallback = (callback: string): boolean => {
   try {
     const url = new URL(callback);
-    const protocol = url.protocol.toLowerCase();
-    return !['http:', 'javascript:', 'data:', 'file:', 'blob:', 'about:'].includes(protocol);
+    const scheme = url.protocol.toLowerCase().replace(/:$/, '');
+    return scheme === 'https' || REGISTERED_APP_SCHEMES.includes(scheme);
   } catch (err) {
     return false;
   }

--- a/src/utils/authRequest.ts
+++ b/src/utils/authRequest.ts
@@ -13,8 +13,7 @@
 // reusable signing credential and is never shared. The user confirms before
 // any answer, and refusals name no account, so a caller cannot learn which
 // accounts live on the device. The requester shown to the user is the
-// callback itself; nothing the caller says about itself is displayed, and the
-// callback must be https or the scheme of a registered app.
+// callback itself; nothing the caller says about itself is displayed.
 
 export interface AuthRequest {
   callback: string;
@@ -33,16 +32,35 @@ export const isAuthRequestDeeplink = (deeplink: string): boolean => {
   }
 };
 
-// The apps that may ask: their own URL schemes. Adding an integrator is a
-// line here, and nothing else on a device can be handed a login proof.
-export const REGISTERED_APP_SCHEMES = ['honeyback'];
+// Schemes the answer must never be sent to: plain-text transports, things
+// that run in a page, messaging handlers, and Android intent URIs. Any other
+// app scheme or https is fine; the user sees the raw callback as the
+// requester and must approve it.
+const REJECTED_CALLBACK_SCHEMES = [
+  'http:',
+  'ftp:',
+  'ftps:',
+  'sftp:',
+  'ws:',
+  'wss:',
+  'intent:',
+  'mailto:',
+  'tel:',
+  'sms:',
+  'smsto:',
+  'javascript:',
+  'data:',
+  'file:',
+  'blob:',
+  'about:',
+  'content:',
+];
 
-// A callback the answer may be sent to: https, or a registered app's scheme.
+// A callback the answer may be sent to: an app's own scheme or https.
 export const isAcceptableCallback = (callback: string): boolean => {
   try {
     const url = new URL(callback);
-    const scheme = url.protocol.toLowerCase().replace(/:$/, '');
-    return scheme === 'https' || REGISTERED_APP_SCHEMES.includes(scheme);
+    return !REJECTED_CALLBACK_SCHEMES.includes(url.protocol.toLowerCase());
   } catch (err) {
     return false;
   }

--- a/src/utils/authRequest.ts
+++ b/src/utils/authRequest.ts
@@ -1,25 +1,40 @@
 // ecency://auth-request: another app asks Ecency to sign the user in and
-// come back on its callback with the username and a login proof, never a key.
+// come back on its callback with the username and a sign-in proof, never a key.
 //
 //   ecency://auth-request?callback=<url>&request_id=<id>[&username=<u>]
 //
-// Success:  <callback>?status=success&username=<u>&code=<login code>&request_id=<id>
+// Success:  <callback>?status=success&username=<u>&code=<proof>&request_id=<id>
 // Refusal:  <callback>?status=error&error=<code>&request_id=<id>
 //
-// The code is what makeHsCode builds: a fresh message signed with the posting
-// key for ecency.app, verifiable the HiveSigner way and good for nothing else.
-// Accounts that hold no posting key here (signed in through HiveSigner or
-// HiveAuth) are answered with use_hivesigner: their stored token is a
-// reusable signing credential and is never shared. The user confirms before
-// any answer, and refusals name no account, so a caller cannot learn which
-// accounts live on the device. The requester shown to the user is the
-// callback itself; nothing the caller says about itself is displayed.
+// The proof is what makeHsLoginProof builds: a HiveSigner-style message signed
+// with the account's key, typed login for the app ecency.app, naming the
+// callback's origin as its audience. HiveSigner's /api/me answers it with the
+// account; its token route, its broadcast route and Ecency's code exchange
+// all refuse it, so unlike a HiveSigner code it cannot become a token or an
+// operation. Receivers verify the signature against the account's keys on
+// chain or through /api/me, and check the timestamp themselves, since
+// HiveSigner does not.
+//
+// Accounts that hold no key here (signed in through HiveSigner or HiveAuth)
+// are answered with use_hivesigner: their stored token is a reusable signing
+// credential and is never shared. The user confirms before any answer, and
+// refusals name no account, so a caller cannot learn which accounts live on
+// the device. The requester shown to the user is the callback itself: nothing
+// the caller says about itself is displayed, and a username that is not a
+// Hive account name makes the whole request invalid, so nothing a caller
+// writes reaches the confirmation either.
 
 export interface AuthRequest {
   callback: string;
   requestId: string | null;
   username: string | null; // a specific account, or the current one when absent
 }
+
+// A Hive account name as the chain accepts it: lowercase, 3 to 16 characters.
+// The same test games-api and the Honeyback client apply.
+const HIVE_ACCOUNT_NAME = /^[a-z][a-z0-9.-]{2,15}$/;
+
+export const isHiveAccountName = (name: string): boolean => HIVE_ACCOUNT_NAME.test(name);
 
 export const isAuthRequestDeeplink = (deeplink: string): boolean => {
   try {
@@ -33,7 +48,8 @@ export const isAuthRequestDeeplink = (deeplink: string): boolean => {
 };
 
 // Schemes the answer must never be sent to: plain-text transports, things
-// that run in a page, messaging handlers, and Android intent URIs. Any other
+// that run in a page, messaging handlers, Android intent URIs, and our own
+// schemes, where the answer would only loop back into this app. Any other
 // app scheme or https is fine; the user sees the raw callback as the
 // requester and must approve it.
 const REJECTED_CALLBACK_SCHEMES = [
@@ -54,6 +70,8 @@ const REJECTED_CALLBACK_SCHEMES = [
   'blob:',
   'about:',
   'content:',
+  'ecency:',
+  'hive:',
 ];
 
 // A callback the answer may be sent to: an app's own scheme or https.
@@ -63,6 +81,17 @@ export const isAcceptableCallback = (callback: string): boolean => {
     return !REJECTED_CALLBACK_SCHEMES.includes(url.protocol.toLowerCase());
   } catch (err) {
     return false;
+  }
+};
+
+// Who a proof is for: the callback's scheme and host, lowercased, such as
+// honeyback://hive or https://games-api.ecency.com.
+export const callbackAudience = (callback: string): string => {
+  try {
+    const url = new URL(callback);
+    return `${url.protocol}//${url.host}`.toLowerCase();
+  } catch (err) {
+    return callback;
   }
 };
 
@@ -80,6 +109,9 @@ export const parseAuthRequestDeeplink = (deeplink: string): AuthRequest | null =
       .replace(/^@/, '')
       .trim()
       .toLowerCase();
+    if (username && !isHiveAccountName(username)) {
+      return null;
+    }
     return {
       callback,
       requestId: url.searchParams.get('request_id'),

--- a/src/utils/authRequest.ts
+++ b/src/utils/authRequest.ts
@@ -1,0 +1,55 @@
+// ecency://auth-request: another app asks Ecency to sign the user in and
+// come back on its callback with the username and a login proof, never a key.
+//
+//   ecency://auth-request?callback=<url>&request_id=<id>[&username=<u>][&app=<name>]
+//
+// Success:  <callback>?status=success&username=<u>&code=<login code>&request_id=<id>
+//       or  <callback>?status=success&username=<u>&access_token=<HiveSigner token>&request_id=<id>
+// Refusal:  <callback>?status=error&error=<code>&message=<text>&request_id=<id>
+//
+// The code is what makeHsCode builds (signed for ecency.app with the posting
+// key); accounts signed in through HiveSigner or HiveAuth hand over their
+// HiveSigner access token instead. Both verify the HiveSigner way.
+
+export interface AuthRequest {
+  callback: string;
+  requestId: string | null;
+  username: string | null; // a specific account, or the current one when absent
+  app: string; // who is asking, for the confirmation only
+}
+
+export const isAuthRequestDeeplink = (deeplink: string): boolean => {
+  try {
+    const url = new URL(deeplink);
+    return (
+      url.protocol.toLowerCase() === 'ecency:' && url.hostname.toLowerCase() === 'auth-request'
+    );
+  } catch (err) {
+    return false;
+  }
+};
+
+export const parseAuthRequestDeeplink = (deeplink: string): AuthRequest | null => {
+  try {
+    const url = new URL(deeplink);
+    const callback =
+      url.searchParams.get('callback') ||
+      url.searchParams.get('redirect_uri') ||
+      url.searchParams.get('return_url');
+    if (!callback) {
+      return null;
+    }
+    const username = (url.searchParams.get('username') || '')
+      .replace(/^@/, '')
+      .trim()
+      .toLowerCase();
+    return {
+      callback,
+      requestId: url.searchParams.get('request_id'),
+      username: username || null,
+      app: (url.searchParams.get('app') || '').trim() || 'another app',
+    };
+  } catch (err) {
+    return null;
+  }
+};

--- a/src/utils/hive-signer-helper.test.ts
+++ b/src/utils/hive-signer-helper.test.ts
@@ -1,0 +1,63 @@
+import { PrivateKey, Signature, sha256 } from '@ecency/sdk';
+import { makeHsCode, makeHsLoginProof } from './hive-signer-helper';
+
+const decode = (token: string) =>
+  JSON.parse(
+    Buffer.from(
+      token.replace(/-/g, '+').replace(/_/g, '/').replace(/\./g, '='),
+      'base64',
+    ).toString(),
+  );
+
+// Checks a token the way HiveSigner and games-api do: the signed bytes are
+// exactly these three fields in this order, rebuilt from the decoded token,
+// and the signature over their sha256 must be by the account's key.
+const verifies = (m: any, key: PrivateKey): boolean => {
+  const bytes = JSON.stringify({
+    signed_message: m.signed_message,
+    authors: m.authors,
+    timestamp: m.timestamp,
+  });
+  const publicKey: any = key.createPublic();
+  return publicKey.verify(sha256(bytes), (Signature as any).from(m.signatures[0]));
+};
+
+describe('hive-signer-helper', () => {
+  const key = PrivateKey.fromSeed('hive-signer-helper test');
+  const otherKey = PrivateKey.fromSeed('another key');
+
+  it('makeHsCode is unchanged: a code for ecency.app, what login exchanges', () => {
+    const before = Date.now() / 1000;
+    const m = decode(makeHsCode('good-karma', key));
+    expect(m.signed_message).toEqual({ type: 'code', app: 'ecency.app' });
+    expect(m.authors).toEqual(['good-karma']);
+    expect(m.timestamp).toBeGreaterThanOrEqual(before - 1);
+    expect(m.timestamp).toBeLessThanOrEqual(Date.now() / 1000 + 1);
+    expect(m.signatures).toHaveLength(1);
+    expect(verifies(m, key)).toBe(true);
+    expect(verifies(m, otherKey)).toBe(false);
+  });
+
+  it('makeHsLoginProof is typed login for ecency.app and names its audience', () => {
+    const m = decode(makeHsLoginProof('good-karma', key, 'honeyback://hive'));
+    expect(m.signed_message).toEqual({
+      type: 'login',
+      app: 'ecency.app',
+      audience: 'honeyback://hive',
+    });
+    expect(Object.keys(m.signed_message)).toEqual(['type', 'app', 'audience']);
+    expect(m.authors).toEqual(['good-karma']);
+    expect(typeof m.timestamp).toBe('number');
+    expect(m.signatures).toHaveLength(1);
+    expect(verifies(m, key)).toBe(true);
+  });
+
+  it('a proof altered for another audience no longer verifies', () => {
+    const a = decode(makeHsLoginProof('good-karma', key, 'honeyback://hive'));
+    const b = {
+      ...a,
+      signed_message: { ...a.signed_message, audience: 'https://elsewhere.example' },
+    };
+    expect(verifies(b, key)).toBe(false);
+  });
+});

--- a/src/utils/hive-signer-helper.ts
+++ b/src/utils/hive-signer-helper.ts
@@ -5,23 +5,49 @@ export interface HiveSignerMessage {
   signed_message: {
     type: string;
     app: string;
+    audience?: string;
   };
   authors: string[];
   timestamp: number;
   signatures?: string[];
 }
 
-export const makeHsCode = (account: string, privateKey: PrivateKey) => {
-  const timestamp = new Date().getTime() / 1000;
-  const messageObj: HiveSignerMessage = {
-    signed_message: { type: 'code', app: 'ecency.app' },
-    authors: [account],
-    timestamp,
-  };
+// The HiveSigner app every message here is signed for. Receivers that verify
+// codes and proofs themselves check this name.
+const HS_APP = 'ecency.app';
+
+const signHsMessage = (messageObj: HiveSignerMessage, privateKey: PrivateKey) => {
   const message = JSON.stringify(messageObj);
   const signature = signer(message, privateKey);
   messageObj.signatures = [signature];
   return b64uEnc(JSON.stringify(messageObj));
+};
+
+// A HiveSigner code: what login exchanges for the account's access and
+// refresh tokens. HiveSigner never expires it, so it only ever goes to
+// Ecency's own token exchange.
+export const makeHsCode = (account: string, privateKey: PrivateKey) => {
+  const timestamp = new Date().getTime() / 1000;
+  return signHsMessage(
+    { signed_message: { type: 'code', app: HS_APP }, authors: [account], timestamp },
+    privateKey,
+  );
+};
+
+// A sign-in proof for another app. Signed like a code but typed login:
+// HiveSigner answers /api/me with the account for it, refuses it at the token
+// route (the role is not code) and refuses every operation at broadcast (the
+// scope is login), so Ecency's code exchange refuses it too. The app stays
+// ecency.app, which is what receivers verify against; the audience names the
+// receiver, so a proof handed to one app is refused by another that checks
+// it. Receivers verify the signature against the account's keys on chain or
+// through /api/me and check the timestamp themselves: HiveSigner does not.
+export const makeHsLoginProof = (account: string, privateKey: PrivateKey, audience: string) => {
+  const timestamp = new Date().getTime() / 1000;
+  return signHsMessage(
+    { signed_message: { type: 'login', app: HS_APP, audience }, authors: [account], timestamp },
+    privateKey,
+  );
 };
 
 export const signer = (message: any, privateKey: PrivateKey) => {

--- a/src/utils/hive-uri.test.ts
+++ b/src/utils/hive-uri.test.ts
@@ -1,0 +1,116 @@
+import * as hiveuri from 'hive-uri';
+import { getFormattedTx, isHiveUri, isWebUrl, normalizeHiveUri } from './hive-uri';
+import { isAuthRequestDeeplink } from './authRequest';
+
+const voteOp: [string, any] = [
+  'vote',
+  { voter: '__signer', author: 'good-karma', permlink: 'hello', weight: 10000 },
+];
+const transferOp: [string, any] = [
+  'transfer',
+  { from: '__signer', to: 'ecency', amount: '1.5 HIVE', memo: '' },
+];
+
+const keys = (has: Partial<Record<'posting' | 'active' | 'owner' | 'memo', boolean>>) =>
+  new Map<string, boolean>(Object.entries({ posting: false, active: false, ...has }));
+
+describe('hive uri', () => {
+  it('normalises ecency://sign/ links to hive://, leaving everything else alone', () => {
+    expect(normalizeHiveUri('ecency://sign/op/abc')).toBe('hive://sign/op/abc');
+    expect(normalizeHiveUri('  ECENCY://sign/tx/abc  ')).toBe('hive://sign/tx/abc');
+    expect(normalizeHiveUri('hive://sign/op/abc')).toBe('hive://sign/op/abc');
+    expect(normalizeHiveUri('ecency://auth-request?callback=x')).toBe(
+      'ecency://auth-request?callback=x',
+    );
+    expect(normalizeHiveUri('https://ecency.com/@good-karma')).toBe(
+      'https://ecency.com/@good-karma',
+    );
+  });
+
+  it('recognises hive:// and ecency://sign/ links only', () => {
+    expect(isHiveUri('hive://sign/op/abc')).toBe(true);
+    expect(isHiveUri('ecency://sign/tx/abc')).toBe(true);
+    expect(isHiveUri(' hive://sign/op/abc ')).toBe(true);
+    expect(isHiveUri('ecency://auth-request?callback=honeyback%3A%2F%2Fhive')).toBe(false);
+    expect(isHiveUri('ecency://login?username=a&callback=b')).toBe(false);
+    expect(isHiveUri('https://ecency.com')).toBe(false);
+    expect(isHiveUri('hive:sign/op/abc')).toBe(false);
+    expect(isHiveUri('')).toBe(false);
+  });
+
+  it('keeps signing links and auth requests apart', () => {
+    const signLink = hiveuri.encodeOp(voteOp);
+    expect(isHiveUri(signLink)).toBe(true);
+    expect(isAuthRequestDeeplink(signLink)).toBe(false);
+    expect(isAuthRequestDeeplink('ecency://sign/op/abc')).toBe(false);
+    expect(isHiveUri('ecency://auth-request?callback=hive%3A%2F%2Fsign%2Fop%2Fabc')).toBe(false);
+  });
+
+  it('tells web urls from everything the OS must open', () => {
+    expect(isWebUrl('https://ecency.com')).toBe(true);
+    expect(isWebUrl(' HTTP://example.com ')).toBe(true);
+    expect(isWebUrl('hive://sign/op/abc')).toBe(false);
+    expect(isWebUrl('mailto:someone@example.com')).toBe(false);
+  });
+
+  it('decodes an encoded operation, in either scheme, to the same transaction', () => {
+    const hiveLink = hiveuri.encodeOp(voteOp);
+    const ecencyLink = `ecency://${hiveLink.slice('hive://'.length)}`;
+    expect(hiveLink.startsWith('hive://sign/op/')).toBe(true);
+    expect(hiveuri.decode(normalizeHiveUri(ecencyLink))).toEqual(hiveuri.decode(hiveLink));
+    expect(hiveuri.decode(hiveLink).tx.operations).toEqual([voteOp]);
+  });
+
+  it('formats a single operation the signer can sign', async () => {
+    const { tx } = hiveuri.decode(hiveuri.encodeOp(voteOp));
+    const formatted = await getFormattedTx(tx, keys({ posting: true }));
+    expect(formatted.opName).toBe('Vote');
+    expect(formatted.tx.operations).toEqual([voteOp]);
+    expect(formatted.tx.expiration).toBe('__expiration');
+  });
+
+  it('fills an empty signer field with __signer', async () => {
+    const { tx } = hiveuri.decode(
+      hiveuri.encodeOp(['vote', { voter: '', author: 'good-karma', permlink: 'hello', weight: 1 }]),
+    );
+    const formatted = await getFormattedTx(tx, keys({ posting: true }));
+    expect(formatted.tx.operations[0][1].voter).toBe('__signer');
+  });
+
+  it('refuses an operation the stored keys cannot sign, naming the authority', async () => {
+    const { tx } = hiveuri.decode(hiveuri.encodeOp(transferOp));
+    await expect(getFormattedTx(tx, keys({ posting: true }))).rejects.toMatchObject({
+      errorKey1: 'qr.invalid_key',
+      authorityKeyType: 'active',
+    });
+  });
+
+  it('formats amounts to three decimals and refuses other assets', async () => {
+    const good = hiveuri.decode(hiveuri.encodeOp(transferOp));
+    const formatted = await getFormattedTx(good.tx, keys({ active: true }));
+    expect(formatted.opName).toBe('Transfer');
+    expect(formatted.tx.operations[0][1].amount).toBe('1.500 HIVE');
+
+    const bad = hiveuri.decode(
+      hiveuri.encodeOp([
+        'transfer',
+        { from: '__signer', to: 'ecency', amount: '1.5 BTC', memo: '' },
+      ]),
+    );
+    await expect(getFormattedTx(bad.tx, keys({ active: true }))).rejects.toMatchObject({
+      errorKey1: 'qr.invalid_amount',
+    });
+  });
+
+  it('refuses multiple operations and unknown ones', async () => {
+    const multi = hiveuri.decode(hiveuri.encodeOps([voteOp, voteOp]));
+    await expect(getFormattedTx(multi.tx, keys({ posting: true }))).rejects.toMatchObject({
+      errorKey1: 'qr.multi_array_ops_alert',
+    });
+
+    const unknown = hiveuri.decode(hiveuri.encodeOp(['no_such_op', { a: 1 }]));
+    await expect(getFormattedTx(unknown.tx, keys({ posting: true }))).rejects.toMatchObject({
+      errorKey1: 'qr.invalid_op',
+    });
+  });
+});


### PR DESCRIPTION
## What

A deep link for other apps (first user: the Honeyback game) to sign a player in with their Ecency account without any key or token leaving Ecency.

```
ecency://auth-request?callback=<url>&request_id=<id>[&username=<u>]
```

- Ecency first confirms with the user, naming the callback as the requester ("honeyback://hive wants to sign you in with your Ecency account. Only your username and a sign-in proof are shared. No key leaves Ecency."). With PIN lock on, the PIN screen gates the next step, as the Hive URI flow does.
- Then it opens the callback with `status=success&username=<u>&code=<proof>&request_id=<id>`. The proof is what `makeHsLoginProof` builds: a HiveSigner-style message signed with the account's posting key (or its active key, for an account signed in with that alone), typed `login` for `ecency.app`, naming the callback's origin (`honeyback://hive`, `https://games-api.ecency.com`) as its `audience`. HiveSigner's `/api/me` answers it with the account; its token route, its broadcast route and Ecency's code exchange refuse it, so unlike a HiveSigner code it cannot become a token or an operation. Receivers verify the signature against the account's keys on chain or through `/api/me`, and check the timestamp themselves. games-api already accepts the `login` type and ignores `audience`.
- Refusals go back as `status=error&error=<code>&request_id=<id>` and never name an account: `user_cancelled`, `not_logged_in`, `pin_required`, `use_hivesigner` (the account signed in through HiveSigner or HiveAuth, so there is no key here to sign with and the stored token is a signing credential, not a proof), `internal_error`.
- `callback` (also `redirect_uri` / `return_url`) may be an app scheme or https; plain-text transports (http, ftp, ws), page schemes (javascript, data, file, blob, about), messaging handlers (mailto, tel, sms), Android intent URIs and our own schemes (ecency, hive) are rejected before anything happens. `username` picks one of the signed-in accounts and must be a Hive account name; without it the current account is used, the normal case since the asking app doesn't know the name.
- Unlike `ecency://login`, which hands over the raw posting key and only works for key-based accounts, this route hands over a proof, and it tells token-based accounts to use HiveSigner directly. `ecency://login` gains the same account-name check on its `username`; the Waves app, its one caller, sends valid names.
- The consent prompts of both routes are translated strings under `deep_link`.

Files: `src/utils/authRequest.ts` (matcher, callback check, audience, parser; tests), `src/utils/hive-signer-helper.ts` (`makeHsLoginProof` next to `makeHsCode`, which is unchanged; tests), `src/hooks/useLinkProcessor.tsx` (the handler next to the login one, wired into `handleLink`; the two consent prompts share one helper), `src/utils/hive-uri.test.ts` (tests for the untouched Hive URI parser, pinning that signing links and auth requests stay apart).

## Review response

- **Spoofable requester (qodo, Codex, CodeRabbit).** The `app` parameter is no longer read or shown; the prompt names the callback (scheme, host, path), so the user sees where the answer goes.
- **Account enumeration / username in refusals (review, qodo).** Consent comes first on every path, and refusals carry only a code, so a caller learns nothing about which accounts live on the device without the owner seeing a prompt. `not_found` folded into `not_logged_in` for the same reason.
- **Bearer token exceeds consent (review, qodo, Codex).** Token-based accounts no longer receive their HiveSigner token; they get `use_hivesigner`. That also removes the token expiry and refresh concerns.
- **A code is a credential, not a proof (review, round 2).** The first version answered with the `makeHsCode` code, which is what login exchanges for the account's HiveSigner tokens. The answer is now the `login`-typed message with an audience described above; `makeHsCode` is unchanged and a test pins its shape.
- **PIN not required when PIN lock is on (Codex).** The handler now routes through the PIN screen with a continuation, as `_handleHiveUri` does, before touching the stored key.
- **Unexpected throw leaves the caller hanging (review).** The callback and request id are captured before the try; both the handler and the completion answer `internal_error` from their catch.
- **Caller text in the consent dialog (review, round 2).** `username` must be a Hive account name, on this route and on `ecency://login`; anything else invalidates the request, so nothing a caller writes is rendered.
- **Callback schemes (CodeRabbit, twice; review, round 2).** The denylist covers ftp, ftps, sftp, ws, wss, intent, sms, content, and our own ecency and hive schemes, with rejection tests. A registered-client allowlist would be a design change and is left as is, consistent with the existing posting-key deep link: the user sees the raw callback as the requester and must approve it. React Native builds a plain VIEW intent from the URL and never parses intent: URIs, so that one could not target a component in any case.
- **Binding the callback to a registered requester (CodeRabbit, heavy).** Out of scope here: there is no app registry to bind to. Showing the real callback in the consent, sharing only a single-purpose proof bound to the callback's origin, and refusing token-based accounts are the mitigations.
- **Active-key-only accounts (review, round 2).** They sign with the active key instead of being sent to HiveSigner.
- **Nits (review).** The `another app` sentinel is gone (the parser no longer returns a label at all), one `_confirmShare(message)` serves both prompts, and both prompts come from `en-US.json`.

## Verified

`authRequest.test.ts` (8), `hive-signer-helper.test.ts` (3, verifying signatures with the SDK's public key) and `hive-uri.test.ts` (10) pass; the full suite, `eslint` and `node scripts/typecheck.js` (0 errors) are clean. Not yet exercised on a device. The counterparts in the game (ecency/games#34, #35) are merged; games-api's verifier requires `app` to be `ecency.app` and accepts the `code` and `login` types, so nothing changes there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `ecency://auth-request` links, enabling sign-in to compatible apps with locally generated, audience-bound login proofs.
  - Added localized confirmation prompts for named and unnamed authorization requests.
  - Signing can use a stored posting or active key; accounts without a usable signing key are directed to HiveSigner.
  - Added support for secure HTTPS and compatible app callback destinations.

- **Security**
  - Blocked unsafe or unsupported callback destinations and invalid Hive account names.
  - Prevented callbacks from looping back into Ecency or Hive schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
