### PR TITLE
fix(feed): cap and strip author-set description in post card summary

### DIFF
--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -262,7 +262,9 @@ const PostCardContentComponent = ({ content, nsfw, handleCardInteraction }: Prop
           <View style={[styles.postDescripton]}>
             {!!_featuredText && <Text style={styles.promotedText}>{_featuredText}</Text>}
             <Text style={styles.title}>{content.title}</Text>
-            <Text style={styles.summary}>{content.summary}</Text>
+            <Text style={styles.summary} numberOfLines={5}>
+              {content.summary}
+            </Text>
           </View>
         </View>
       </TouchableOpacity>

--- a/src/utils/postParser.test.ts
+++ b/src/utils/postParser.test.ts
@@ -14,7 +14,18 @@ import { MutedReason } from '../providers/hive/hive.types';
 
 jest.mock('@ecency/render-helper', () => ({
   renderPostBody: jest.fn((post) => `<p>${post.body || ''}</p>`),
-  postBodySummary: jest.fn(() => 'summary text'),
+  // Mirrors the real helper's contract for these tests: a raw string is
+  // stripped of markdown and capped at `length`; an entry yields a fixed body summary.
+  postBodySummary: jest.fn((input, length) =>
+    typeof input === 'string'
+      ? input
+          .replace(/https?:\/\/\S+/g, '')
+          .replace(/[#*![\]()]/g, '')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, length)
+      : 'summary text',
+  ),
   catchPostImage: jest.fn((post, w, _h) =>
     w > 100 ? 'https://img.com/cover.jpg' : 'https://img.com/thumb.jpg',
   ),
@@ -395,12 +406,56 @@ describe('parsePost', () => {
     expect(result!.body).toBe('');
   });
 
-  it('uses json_metadata description for summary when available', () => {
-    const post = makePost({
-      json_metadata: { tags: ['test'], description: 'custom desc' },
+  describe('summary', () => {
+    const { postBodySummary } = jest.requireMock('@ecency/render-helper');
+
+    beforeEach(() => {
+      postBodySummary.mockClear();
     });
-    const result = parsePost(post, 'viewer', false);
-    expect(result!.summary).toBe('custom desc');
+
+    it('uses json_metadata description for summary when available', () => {
+      const post = makePost({
+        json_metadata: { tags: ['test'], description: 'custom desc' },
+      });
+      const result = parsePost(post, 'viewer', false);
+      expect(result!.summary).toBe('custom desc');
+    });
+
+    it('strips markdown from the description and caps it at the summary length', () => {
+      // Some apps write the whole markdown body into description.
+      const description = `![Image](https://x/y.png)\n\n# Heading\n\n* **bold** item\n`.repeat(40);
+      const post = makePost({ json_metadata: { tags: ['test'], description } });
+      const result = parsePost(post, 'viewer', false);
+      expect(postBodySummary).toHaveBeenCalledWith(description.trim(), 150, expect.any(String));
+      expect(result!.summary.length).toBeLessThanOrEqual(150);
+      expect(result!.summary).not.toContain('#');
+      expect(result!.summary).not.toContain('**');
+    });
+
+    it('ignores a non-string description and summarises the body instead', () => {
+      const post = makePost({ json_metadata: { tags: ['test'], description: { en: 'x' } } });
+      const result = parsePost(post, 'viewer', false);
+      expect(result!.summary).toBe('summary text');
+      expect(postBodySummary).toHaveBeenCalledWith(
+        expect.objectContaining({ body: post.body }),
+        150,
+        expect.any(String),
+      );
+    });
+
+    it('falls back to the body when the description is blank or strips to nothing', () => {
+      expect(
+        parsePost(makePost({ json_metadata: { description: '   ' } }), 'viewer', false)!.summary,
+      ).toBe('summary text');
+      // An image-only description renders to an empty summary.
+      expect(
+        parsePost(
+          makePost({ json_metadata: { description: '![](https://x/y.png)' } }),
+          'viewer',
+          false,
+        )!.summary,
+      ).toBe('summary text');
+    });
   });
 
   describe('parseTags (via parsePost)', () => {

--- a/src/utils/postParser.test.ts
+++ b/src/utils/postParser.test.ts
@@ -14,21 +14,16 @@ import { MutedReason } from '../providers/hive/hive.types';
 
 jest.mock('@ecency/render-helper', () => ({
   renderPostBody: jest.fn((post) => `<p>${post.body || ''}</p>`),
-  // Mirrors the real helper's contract for these tests: a raw string is
-  // stripped of markdown and capped at `length`; an entry yields a fixed body summary.
-  postBodySummary: jest.fn((input, length) =>
-    typeof input === 'string'
-      ? input
-          .replace(/https?:\/\/\S+/g, '')
-          .replace(/[#*![\]()]/g, '')
-          .replace(/\s+/g, ' ')
-          .trim()
-          .slice(0, length)
-      : 'summary text',
-  ),
+  postBodySummary: jest.fn(() => 'summary text'),
   catchPostImage: jest.fn((post, w, _h) =>
     w > 100 ? 'https://img.com/cover.jpg' : 'https://img.com/thumb.jpg',
   ),
+}));
+
+// Summary behaviour is specified in postSummary.test.ts against the real
+// render-helper; here only the wiring into parsePost matters.
+jest.mock('./postSummary', () => ({
+  parseSummary: jest.fn((post) => `summary of ${post.author}`),
 }));
 
 jest.mock('expo-image', () => ({
@@ -406,56 +401,12 @@ describe('parsePost', () => {
     expect(result!.body).toBe('');
   });
 
-  describe('summary', () => {
-    const { postBodySummary } = jest.requireMock('@ecency/render-helper');
-
-    beforeEach(() => {
-      postBodySummary.mockClear();
-    });
-
-    it('uses json_metadata description for summary when available', () => {
-      const post = makePost({
-        json_metadata: { tags: ['test'], description: 'custom desc' },
-      });
-      const result = parsePost(post, 'viewer', false);
-      expect(result!.summary).toBe('custom desc');
-    });
-
-    it('strips markdown from the description and caps it at the summary length', () => {
-      // Some apps write the whole markdown body into description.
-      const description = `![Image](https://x/y.png)\n\n# Heading\n\n* **bold** item\n`.repeat(40);
-      const post = makePost({ json_metadata: { tags: ['test'], description } });
-      const result = parsePost(post, 'viewer', false);
-      expect(postBodySummary).toHaveBeenCalledWith(description.trim(), 150, expect.any(String));
-      expect(result!.summary.length).toBeLessThanOrEqual(150);
-      expect(result!.summary).not.toContain('#');
-      expect(result!.summary).not.toContain('**');
-    });
-
-    it('ignores a non-string description and summarises the body instead', () => {
-      const post = makePost({ json_metadata: { tags: ['test'], description: { en: 'x' } } });
-      const result = parsePost(post, 'viewer', false);
-      expect(result!.summary).toBe('summary text');
-      expect(postBodySummary).toHaveBeenCalledWith(
-        expect.objectContaining({ body: post.body }),
-        150,
-        expect.any(String),
-      );
-    });
-
-    it('falls back to the body when the description is blank or strips to nothing', () => {
-      expect(
-        parsePost(makePost({ json_metadata: { description: '   ' } }), 'viewer', false)!.summary,
-      ).toBe('summary text');
-      // An image-only description renders to an empty summary.
-      expect(
-        parsePost(
-          makePost({ json_metadata: { description: '![](https://x/y.png)' } }),
-          'viewer',
-          false,
-        )!.summary,
-      ).toBe('summary text');
-    });
+  it('derives summary through parseSummary', () => {
+    const { parseSummary } = jest.requireMock('./postSummary');
+    const post = makePost({ json_metadata: { tags: ['test'], description: 'custom desc' } });
+    const result = parsePost(post, 'viewer', false);
+    expect(parseSummary).toHaveBeenCalledWith(result);
+    expect(result!.summary).toBe('summary of testuser');
   });
 
   describe('parseTags (via parsePost)', () => {

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -1,6 +1,5 @@
 import { get } from 'lodash';
-import { Platform } from 'react-native';
-import { postBodySummary, renderPostBody, catchPostImage } from '@ecency/render-helper';
+import { renderPostBody, catchPostImage } from '@ecency/render-helper';
 import { getContentModerationReason } from '@ecency/sdk';
 import { Image as ExpoImage } from 'expo-image';
 
@@ -9,27 +8,7 @@ import parseAsset from './parseAsset';
 import { getResizedAvatar, shouldPrefetchImages } from './image';
 import { parseReputation } from './user';
 import { calculateVoteReward } from './vote';
-
-const SUMMARY_LENGTH = 150;
-
-/**
- * Card summary: an author-set json_metadata.description wins over the generated
- * body summary, but json_metadata is untrusted on-chain data. Some apps write the
- * whole markdown body (or a non-string) into description, which used to render
- * raw markdown of unbounded length in the feed. Route it through the same
- * summary function as the body so both paths yield plain text of the same cap.
- */
-export const parseSummary = (post: any): string => {
-  const platform = Platform.OS as any;
-  const declared = post?.json_metadata?.description;
-  if (typeof declared === 'string' && declared.trim()) {
-    const summary = postBodySummary(declared.trim(), SUMMARY_LENGTH, platform);
-    if (summary) {
-      return summary;
-    }
-  }
-  return postBodySummary(post, SUMMARY_LENGTH, platform);
-};
+import { parseSummary } from './postSummary';
 
 export const parsePost = (
   post: any,

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -10,6 +10,27 @@ import { getResizedAvatar, shouldPrefetchImages } from './image';
 import { parseReputation } from './user';
 import { calculateVoteReward } from './vote';
 
+const SUMMARY_LENGTH = 150;
+
+/**
+ * Card summary: an author-set json_metadata.description wins over the generated
+ * body summary, but json_metadata is untrusted on-chain data. Some apps write the
+ * whole markdown body (or a non-string) into description, which used to render
+ * raw markdown of unbounded length in the feed. Route it through the same
+ * summary function as the body so both paths yield plain text of the same cap.
+ */
+export const parseSummary = (post: any): string => {
+  const platform = Platform.OS as any;
+  const declared = post?.json_metadata?.description;
+  if (typeof declared === 'string' && declared.trim()) {
+    const summary = postBodySummary(declared.trim(), SUMMARY_LENGTH, platform);
+    if (summary) {
+      return summary;
+    }
+  }
+  return postBodySummary(post, SUMMARY_LENGTH, platform);
+};
+
 export const parsePost = (
   post: any,
   currentUserName: string | null | undefined,
@@ -107,8 +128,7 @@ export const parsePost = (
   if (!isList) {
     post.body = renderPostBody({ ...post, last_update: post.updated }, true, false);
   }
-  // Use description from json_metadata if available, otherwise generate summary from body
-  post.summary = post.json_metadata?.description || postBodySummary(post, 150, Platform.OS as any);
+  post.summary = parseSummary(post);
   post.max_payout = parseAsset(post.max_accepted_payout).amount || 0;
   post.is_declined_payout = !!post.max_accepted_payout && post.max_payout === 0;
 

--- a/src/utils/postSummary.test.ts
+++ b/src/utils/postSummary.test.ts
@@ -1,0 +1,95 @@
+// Deliberately NOT mocking @ecency/render-helper: the guarantees below (markdown
+// stripped, cap honoured, text without spaces still excerpted) only mean
+// something against the real summariser.
+import { postBodySummary } from '@ecency/render-helper';
+import { parseSummary, summarizeText, SUMMARY_LENGTH } from './postSummary';
+
+// What a client that copies the whole post into `description` publishes.
+const MARKDOWN_BODY = [
+  'https://youtu.be/abc123',
+  '',
+  '![Image](https://images.hive.blog/cover.png)',
+  '',
+  '# Dev Update',
+  '',
+  '## Inbox Rendering Fix',
+  '',
+  '* Fixed an issue where text lines could appear in the **wrong order** on the Inbox page.',
+  '* Added **preLinkMentions** processing to **hiveBodyRenderer.ts**.',
+  '',
+  '| | |',
+  '|---|---|',
+  '| [![](https://images.hive.blog/a.png)](https://example.com/) | [Docs](https://x.io/d) |',
+]
+  .join('\n')
+  .repeat(6);
+
+const CJK = '這是一段完全沒有空格的中文描述文字'.repeat(20);
+
+const post = (description: unknown, body = 'Plain body text for the fallback.') => ({
+  author: 'alice',
+  permlink: `summary-${Math.random().toString(36).slice(2)}`,
+  updated: '2024-01-01T00:00:00',
+  body,
+  json_metadata: description === undefined ? {} : { description },
+});
+
+describe('summarizeText', () => {
+  it('strips markdown and caps at the requested length', () => {
+    const text = summarizeText(MARKDOWN_BODY, SUMMARY_LENGTH);
+    // postBodySummary's joiner may overshoot the cap by one word, never by more.
+    expect(text.length).toBeLessThanOrEqual(SUMMARY_LENGTH + 10);
+    expect(text.startsWith('Dev Update Inbox Rendering Fix')).toBe(true);
+    expect(text).not.toMatch(/[#*|]|!\[|http/);
+  });
+
+  it('keeps a bounded excerpt of text without spaces instead of dropping it', () => {
+    expect(postBodySummary(CJK, SUMMARY_LENGTH, 'ios')).toBe(''); // the helper's own behaviour
+    const text = summarizeText(CJK, SUMMARY_LENGTH);
+    expect(text).toBe(CJK.slice(0, SUMMARY_LENGTH));
+  });
+
+  it('cuts space-less text by code point, never through a surrogate pair', () => {
+    const text = summarizeText('🎉'.repeat(400), SUMMARY_LENGTH);
+    expect(Array.from(text)).toHaveLength(SUMMARY_LENGTH);
+    expect(text).toBe('🎉'.repeat(SUMMARY_LENGTH));
+  });
+
+  it('returns an empty string for text that strips to nothing', () => {
+    expect(summarizeText('![](https://images.hive.blog/x.png)', SUMMARY_LENGTH)).toBe('');
+  });
+});
+
+describe('parseSummary', () => {
+  it('keeps a short author-written description, trimmed', () => {
+    expect(parseSummary(post('  Author summary  '))).toBe('Author summary');
+  });
+
+  it('strips markdown from a whole-body description and caps it', () => {
+    const text = parseSummary(post(MARKDOWN_BODY));
+    expect(text.length).toBeLessThanOrEqual(SUMMARY_LENGTH + 10);
+    expect(text.startsWith('Dev Update Inbox Rendering Fix')).toBe(true);
+  });
+
+  it('keeps an excerpt of a description without spaces', () => {
+    expect(parseSummary(post(CJK))).toBe(CJK.slice(0, SUMMARY_LENGTH));
+  });
+
+  it('ignores a non-string description and summarises the body', () => {
+    expect(parseSummary(post({ en: 'nope' }))).toBe('Plain body text for the fallback.');
+  });
+
+  it('falls back to the body when the description is blank', () => {
+    expect(parseSummary(post('   '))).toBe('Plain body text for the fallback.');
+  });
+
+  it('falls back to the body when the description strips to nothing', () => {
+    expect(parseSummary(post('![](https://images.hive.blog/x.png)'))).toBe(
+      'Plain body text for the fallback.',
+    );
+  });
+
+  it('summarises the body when there is no description', () => {
+    expect(parseSummary(post(undefined, '## Body **heading** here'))).toBe('Body heading here');
+  });
+});

--- a/src/utils/postSummary.ts
+++ b/src/utils/postSummary.ts
@@ -1,0 +1,41 @@
+import { Platform } from 'react-native';
+import { postBodySummary } from '@ecency/render-helper';
+
+export const SUMMARY_LENGTH = 150;
+
+const platform = Platform.OS as 'ios' | 'android';
+
+/**
+ * Plain-text excerpt of an author-written string, capped at `length` characters.
+ *
+ * postBodySummary truncates on spaces and drops a first "word" longer than the
+ * cap, so text without spaces (CJK prose, a long hashtag) summarises to "". When
+ * that happens, take the untruncated plain text and cut it by code point instead,
+ * so such a description still yields a bounded excerpt.
+ */
+export const summarizeText = (text: string, length = SUMMARY_LENGTH): string => {
+  const summary = postBodySummary(text, length, platform);
+  if (summary) {
+    return summary;
+  }
+  const plain = postBodySummary(text, 0, platform);
+  return plain ? Array.from(plain).slice(0, length).join('') : '';
+};
+
+/**
+ * Card summary: an author-set json_metadata.description wins over the generated
+ * body summary, but json_metadata is untrusted on-chain data. Some apps write the
+ * whole markdown body (or a non-string) into description, which used to render
+ * raw markdown of unbounded length in the feed. Route it through the same
+ * summary function as the body so both paths yield plain text of the same cap.
+ */
+export const parseSummary = (post: any): string => {
+  const declared = post?.json_metadata?.description;
+  if (typeof declared === 'string' && declared.trim()) {
+    const summary = summarizeText(declared.trim(), SUMMARY_LENGTH);
+    if (summary) {
+      return summary;
+    }
+  }
+  return postBodySummary(post, SUMMARY_LENGTH, platform);
+};


### PR DESCRIPTION
Fixes #3545

## What changed
- New `src/utils/postSummary.ts` with `parseSummary` and `summarizeText`. A string `json_metadata.description` is routed through `postBodySummary` (markdown stripped, 150 chars) exactly like the body, a non-string description is ignored, and a description that strips to nothing (image-only) falls back to the body summary. `parsePost` uses it.
- Text without spaces (CJK prose, a long hashtag) makes `postBodySummary` return `""`, because it truncates on spaces and drops a first word longer than the cap. `summarizeText` then takes the untruncated plain text and cuts it by code point, so such a description still yields a bounded excerpt instead of being dropped.
- The post card summary `Text` gets `numberOfLines={5}` as a hard stop.
- Every consumer of `post.summary` (post card, reply header, chat link preview, quick post modal) benefits, since the cap lives in the parser.

## Why
Some publishing clients copy the whole markdown body into `description`. The card rendered that value verbatim, so one post expanded to a screen-tall block of raw markdown in the feed.

## Test plan
- `postSummary.test.ts` runs against the real render-helper (no mock): markdown description stripped and capped, space-less description excerpted, code-point cut never splits a surrogate pair, non-string, blank and image-only descriptions fall back to the body.
- `postParser.test.ts` keeps a wiring check that `parsePost` derives `summary` through `parseSummary`.
- Each guard was mutated in turn (raw passthrough, no string check, no empty fallback, no space-less excerpt, UTF-16 slice, unbounded excerpt) and the suite went red every time.
- `npx eslint`, `node scripts/typecheck.js` and jest pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Post summaries are limited to five lines for a cleaner, more consistent card layout.
  - Summaries prioritize available metadata descriptions, remove markdown formatting, normalize content, and cap text at 150 characters.
  - When metadata descriptions are unavailable or blank, summaries fall back to the post body.
  - Summary handling now better supports text without spaces and special characters while retaining readable truncated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->